### PR TITLE
The treatment of MathML in libCellML

### DIFF
--- a/docs/current_thinking.rst
+++ b/docs/current_thinking.rst
@@ -4,7 +4,7 @@
 Current Thinking for libCellML
 ==============================
 
-This document simply outlines some of the rationale that has an influence on how the codebase is developed.
+This document simply outlines some of the current rationale that has an influence on how the codebase is developed.
 
 - Not dealing with external documents.
  
@@ -15,4 +15,8 @@ This document simply outlines some of the rationale that has an influence on how
 - Serialise and deserialise from a string.
 - Present a useful interface not one tied to XML structure.
 - Validation is going to be quite separate (you are free to make invalid CellML models).
+- Not creating our own MathML object model
 
+  - Treat MathML as a string.
+  - Enables libCellML development to focus on getting core "CellML" support.
+  - Expect to provide another layer that would handle MathML as a separate thing.


### PR DESCRIPTION
As we get closer to implementing some of the use-cases involving MathML in libCellML, it would be good to make sure we are all on the same page in terms of how integrated MathML support will be in "core" libCellML. I have added a couple of points to the current thinking document to describe how I see it happening, at least for now, and I think this captures what @hsorby and I have been talking about.
