### PR TITLE
Update use cases: add variable initial values and modify connections

### DIFF
--- a/docs/usecases.rst
+++ b/docs/usecases.rst
@@ -60,12 +60,21 @@ Use-cases for libCellML
    #. a model with variables
    
       a. model from *1.iv.a* and define a variable with a valid name and units dimensionless
+         #. with a valid variable initial value of 0.0
+         #. with an invalid variable initial value
+
       #. model from *1.iv.a* and define a variable with an invalid name and units dimensionless
       #. model from *1.iv.a* and define a variable with a valid name and invalid units name.
-      #. model from *1.vi.a*, define a single variable in each component with units dimensionless
-      
-         #. private interface in the parent and public interface in the child components and connect the variable in both children to the parent.
-         #. public interface in all components and connect the variables in the children to the parent
+      #. a model with a single component containing two variables.
+
+         #. with valid variable initial values of 1.0 and -1.0, respectively.
+
+   #. a model with connections
+
+      a. model with one component encapsulating two children components (1.vi.a), each child containing a single variable with units dimensionless
+
+         #. with a private interface in the parent and public interface in the child components and connect the variable in both children to the parent.
+         #. with a public interface in all components and connect the variables in the children to the parent
          
    #. a model with maths and variables
    

--- a/docs/usecases.rst
+++ b/docs/usecases.rst
@@ -60,6 +60,7 @@ Use-cases for libCellML
    #. a model with variables
    
       a. model from *1.iv.a* and define a variable with a valid name and units dimensionless
+
          #. with a valid variable initial value of 0.0
          #. with an invalid variable initial value
 
@@ -71,7 +72,7 @@ Use-cases for libCellML
 
    #. a model with connections
 
-      a. model with one component encapsulating two children components (1.vi.a), each child containing a single variable with units dimensionless
+      a. model from *1.vi.a*, each child containing a single variable
 
          #. with a private interface in the parent and public interface in the child components and connect the variable in both children to the parent.
          #. with a public interface in all components and connect the variables in the children to the parent

--- a/docs/usecases.rst
+++ b/docs/usecases.rst
@@ -62,7 +62,6 @@ Use-cases for libCellML
       a. model from *1.iv.a* and define a variable with a valid name and units dimensionless
 
          #. with a valid variable initial value of 0.0
-         #. with an invalid variable initial value
 
       #. model from *1.iv.a* and define a variable with an invalid name and units dimensionless
       #. model from *1.iv.a* and define a variable with a valid name and invalid units name.

--- a/docs/usecases.rst
+++ b/docs/usecases.rst
@@ -68,6 +68,7 @@ Use-cases for libCellML
       #. a model with a single component containing two variables.
 
          #. with valid variable initial values of 1.0 and -1.0, respectively.
+         #. one with an initial value of 1.0 and the other with an initial value of the first variable.
 
    #. a model with connections
 


### PR DESCRIPTION
As per discussion on issue #63 and pull #64, this updates the use-cases document to include support for variable initial values and separates the implementation of connections from variables.

If accepted, I plan to add support for initial values as a second pull request under issue #63 and set up connections as its own issue/pull set.
