### PR TITLE
Bugfix: remove extraneous text from Apache license

### DIFF
--- a/src/api/libcellml/component.h
+++ b/src/api/libcellml/component.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_COMPONENT_H

--- a/src/api/libcellml/componententity.h
+++ b/src/api/libcellml/componententity.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_COMPONENTENTITY_H

--- a/src/api/libcellml/entity.h
+++ b/src/api/libcellml/entity.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_ENTITY_H_

--- a/src/api/libcellml/enumerations.h
+++ b/src/api/libcellml/enumerations.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_ENUMERATIONS_H_

--- a/src/api/libcellml/import.h
+++ b/src/api/libcellml/import.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_IMPORT_H_

--- a/src/api/libcellml/importedentity.h
+++ b/src/api/libcellml/importedentity.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_IMPORTEDENTITY_H

--- a/src/api/libcellml/model.h
+++ b/src/api/libcellml/model.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_MODEL_H_

--- a/src/api/libcellml/module/libcellml
+++ b/src/api/libcellml/module/libcellml
@@ -12,7 +12,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_MODULE_LIBCELLML_H_

--- a/src/api/libcellml/namedentity.h
+++ b/src/api/libcellml/namedentity.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_NAMEABLE_H

--- a/src/api/libcellml/types.h
+++ b/src/api/libcellml/types.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_TYPES_H_

--- a/src/api/libcellml/units.h
+++ b/src/api/libcellml/units.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_UNITS_H

--- a/src/api/libcellml/variable.h
+++ b/src/api/libcellml/variable.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_VARIABLE_H

--- a/src/api/libcellml/version.h
+++ b/src/api/libcellml/version.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_VERSION_H_

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "libcellml/component.h"

--- a/src/componententity.cpp
+++ b/src/componententity.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "libcellml/componententity.h"

--- a/src/configure/libcellml_config.h.in
+++ b/src/configure/libcellml_config.h.in
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #ifndef LIBCELLML_LIBCELLML_CONFIG_H

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "libcellml/entity.h"

--- a/src/import.cpp
+++ b/src/import.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "libcellml/import.h"

--- a/src/importedentity.cpp
+++ b/src/importedentity.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 #include "libcellml/importedentity.h"
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "libcellml/model.h"

--- a/src/namedentity.cpp
+++ b/src/namedentity.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 #include "libcellml/namedentity.h"
 

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 #include "libcellml/units.h"
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 #include "libcellml/variable.h"
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "libcellml/version.h"

--- a/tests/component/component.cpp
+++ b/tests/component/component.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"

--- a/tests/component/encapsulation.cpp
+++ b/tests/component/encapsulation.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"

--- a/tests/connection/connection.cpp
+++ b/tests/connection/connection.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"

--- a/tests/coverage/coverage.cpp
+++ b/tests/coverage/coverage.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"

--- a/tests/model/component_import.cpp
+++ b/tests/model/component_import.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"

--- a/tests/model/model.cpp
+++ b/tests/model/model.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"

--- a/tests/model/units_import.cpp
+++ b/tests/model/units_import.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"

--- a/tests/variable/variable.cpp
+++ b/tests/variable/variable.cpp
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.Some license of other
+limitations under the License.
 */
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
Addresses issue #99 
