### PR TITLE
Changes to unit prefix handling

### DIFF
--- a/src/api/libcellml/enumerations.h
+++ b/src/api/libcellml/enumerations.h
@@ -48,7 +48,6 @@ enum PREFIXES
     PREFIX_KILO  =   3,
     PREFIX_HECTO =   2,
     PREFIX_DECA  =   1,
-    PREFIX_UNIT  =   0,
     PREFIX_DECI  =  -1,
     PREFIX_CENTI =  -2,
     PREFIX_MILLI =  -3,

--- a/src/api/libcellml/units.h
+++ b/src/api/libcellml/units.h
@@ -104,6 +104,21 @@ public:
      * Add a unit as a child of this Units.  This method takes optional arguments
      * exponent, multiplier and offset.
      * @param name The name of the unit to add.
+     * @param prefix The string prefix for the unit.
+     * @param exponent The exponent.
+     * @param multiplier The multiplier.
+     * @param offset The offset.
+     */
+    void addUnit(const std::string &name, const std::string &prefix, double exponent=1.0,
+                 double multiplier=1.0, double offset=0.0);
+
+    /**
+     * @brief Add a unit to this Units.
+     * Add a unit as a child of this Units.  This method takes optional arguments
+     * exponent, multiplier and offset.
+     *
+     * @overload
+     * @param name The name of the unit to add.
      * @param prefix The prefix for the unit, one of PREFIXES.
      * @param exponent The exponent.
      * @param multiplier The multiplier.

--- a/src/api/libcellml/units.h
+++ b/src/api/libcellml/units.h
@@ -124,7 +124,7 @@ public:
      * @param multiplier The multiplier.
      * @param offset The offset.
      */
-    void addUnit(const std::string &units, int prefix, double exponent=1.0,
+    void addUnit(const std::string &units, double prefix, double exponent,
                  double multiplier=1.0, double offset=0.0);
 
     /**

--- a/src/api/libcellml/units.h
+++ b/src/api/libcellml/units.h
@@ -102,14 +102,14 @@ public:
     /**
      * @brief Add a unit to this Units.
      * Add a unit as a child of this Units.  This method takes optional arguments
-     * multiplier and offset.
-     * @param units The name of the unit to add.
+     * exponent, multiplier and offset.
+     * @param name The name of the unit to add.
      * @param prefix The prefix for the unit, one of PREFIXES.
      * @param exponent The exponent.
      * @param multiplier The multiplier.
      * @param offset The offset.
      */
-    void addUnit(const std::string &units, PREFIXES prefix, double exponent=1.0,
+    void addUnit(const std::string &name, PREFIXES prefix, double exponent=1.0,
                  double multiplier=1.0, double offset=0.0);
 
     /**
@@ -118,13 +118,13 @@ public:
      * multiplier and offset.
      *
      * @overload
-     * @param units The name of the unit to add.
-     * @param prefix The prefix for the unit expressed as an integer.
+     * @param name The name of the unit to add.
+     * @param prefix The prefix for the unit expressed as a double.
      * @param exponent The exponent.
      * @param multiplier The multiplier.
      * @param offset The offset.
      */
-    void addUnit(const std::string &units, double prefix, double exponent,
+    void addUnit(const std::string &name, double prefix, double exponent,
                  double multiplier=1.0, double offset=0.0);
 
     /**
@@ -133,19 +133,19 @@ public:
      * and an exponent only.
      *
      * @overload
-     * @param units The name of the unit to add.
+     * @param name The name of the unit to add.
      * @param exponent The exponent for the unit.
      */
-    void addUnit(const std::string &units, double exponent);
+    void addUnit(const std::string &name, double exponent);
 
     /**
      * @brief Add a unit to this Units.
      * Add a unit as a child of this Units, this variant specified with only a name.
      *
      * @overload
-     * @param units The name of the unit to add.
+     * @param name The name of the unit to add.
      */
-    void addUnit(const std::string &units);
+    void addUnit(const std::string &name);
 
     /**
      * @brief Set the source of the units for this Units.

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -39,7 +39,7 @@ std::string prefixToString(PREFIXES prefix);
  */
 struct Unit
 {
-    std::string mUnits; /**< Name for the unit.*/
+    std::string mName; /**< Name for the unit.*/
     std::string mPrefix = "0.0"; /**< String expression of the prefix for the unit.*/
     double mExponent = 1.0; /**< Exponent for the unit.*/
     double mMultiplier = 1.0; /**< Multiplier for the unit.*/
@@ -130,7 +130,7 @@ std::string Units::doSerialisation(FORMATS format) const
                         if (u.mPrefix != "0.0") {
                             repr += " prefix=\"" + u.mPrefix + "\"";
                         }
-                        repr += " units=\"" + u.mUnits + "\"";
+                        repr += " units=\"" + u.mName + "\"";
                         repr += "/>";
                     }
                     repr += "</units>";
@@ -152,11 +152,11 @@ void Units::setBaseUnit(bool state)
     mPimpl->mBaseUnit = state;
 }
 
-void Units::addUnit(const std::string & units, PREFIXES prefix, double exponent,
+void Units::addUnit(const std::string &name, PREFIXES prefix, double exponent,
              double multiplier, double offset)
 {
     Unit u;
-    u.mUnits = units;
+    u.mName = name;
     u.mPrefix = prefixToString(prefix);
     u.mExponent = exponent;
     u.mMultiplier = multiplier;
@@ -165,12 +165,12 @@ void Units::addUnit(const std::string & units, PREFIXES prefix, double exponent,
     mPimpl->mUnits.push_back(u);
 }
 
-void Units::addUnit(const std::string & units, double prefix, double exponent,
+void Units::addUnit(const std::string &name, double prefix, double exponent,
              double multiplier, double offset)
 {
     Unit u;
     std::ostringstream strs;
-    u.mUnits = units;
+    u.mName = name;
     if (prefix != 0.0) {
         strs << prefix;
         u.mPrefix = strs.str();
@@ -182,14 +182,14 @@ void Units::addUnit(const std::string & units, double prefix, double exponent,
     mPimpl->mUnits.push_back(u);
 }
 
-void Units::addUnit(const std::string &units, double exponent)
+void Units::addUnit(const std::string &name, double exponent)
 {
-    addUnit(units, 0.0, exponent, 1.0, 0.0);
+    addUnit(name, 0.0, exponent, 1.0, 0.0);
 }
 
-void Units::addUnit(const std::string &units)
+void Units::addUnit(const std::string &name)
 {
-    addUnit(units, 0.0, 1.0, 1.0, 0.0);
+    addUnit(name, 0.0, 1.0, 1.0, 0.0);
 
 }
 

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -54,34 +54,6 @@ std::map<PREFIXES, std::string> prefixToString =
 };
 
 /**
- * @brief Map a selection of strings to their PREFIXES form.
- * An internal map used to convert a selection of strings to PREFIXES.
- */
-std::map<std::string, PREFIXES> stringToPrefix =
-{
-    {"atto", PREFIX_ATTO},
-    {"centi", PREFIX_CENTI},
-    {"deca", PREFIX_DECA},
-    {"deci", PREFIX_DECI},
-    {"exa", PREFIX_EXA},
-    {"femto", PREFIX_FEMTO},
-    {"giga", PREFIX_GIGA},
-    {"hecto", PREFIX_HECTO},
-    {"kilo", PREFIX_KILO},
-    {"mega", PREFIX_MEGA},
-    {"micro", PREFIX_MICRO},
-    {"milli", PREFIX_MILLI},
-    {"nano", PREFIX_NANO},
-    {"peta", PREFIX_PETA},
-    {"pico", PREFIX_PICO},
-    {"tera", PREFIX_TERA},
-    {"yocto", PREFIX_YOCTO},
-    {"yotta", PREFIX_YOTTA},
-    {"zepto", PREFIX_ZEPTO},
-    {"zetta", PREFIX_ZETTA}
-};
-
-/**
  * @brief The Unit struct.
  * An internal structure to capture a unit definition.  The
  * prefix can be expressed using either an integer or an enum.
@@ -201,30 +173,15 @@ void Units::addUnit(const std::string &name, const std::string &prefix, double e
 {
     Unit u;
     u.mName = name;
-    auto search = stringToPrefix.find(prefix);
-    // Check if this is a SI prefix string
-    if (search != stringToPrefix.end()) {
+    // Allow all nonzero user-specified prefixes
+    try
+    {
+        double prefixDouble = std::stod(prefix);
+        if (prefixDouble != 0.0) {
+            u.mPrefix = prefix;
+        }
+    } catch(...) {
         u.mPrefix = prefix;
-    } else {
-        // Check if this is a real-valued prefix string
-        try
-        {
-            double prefixDouble = std::stod(prefix);
-            // Check if this is the default value
-            if (prefixDouble != 0.0) {
-                u.mPrefix = prefix;
-            }
-        }
-        catch(std::invalid_argument)
-        {
-            throw std::invalid_argument("Specified string prefix " + prefix +
-                                    " is not a standard SI prefix or a real number.");
-        }
-        catch(std::out_of_range)
-        {
-            throw std::out_of_range("Specified string prefix " + prefix +
-                                    " is not a standard SI prefix or a real number.");
-        }
     }
     if (exponent != 1.0) {
         std::ostringstream strs;

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -179,7 +179,9 @@ void Units::addUnit(const std::string &name, const std::string &prefix, double e
         if (prefixDouble != 0.0) {
             u.mPrefix = prefix;
         }
-    } catch(...) {
+    } catch (std::invalid_argument) {
+        u.mPrefix = prefix;
+    } catch (std::out_of_range) {
         u.mPrefix = prefix;
     }
     if (exponent != 1.0) {
@@ -220,13 +222,12 @@ void Units::addUnit(const std::string &name, double prefix, double exponent,
 
 void Units::addUnit(const std::string &name, double exponent)
 {
-    addUnit(name, 0.0, exponent, 1.0, 0.0);
+    addUnit(name, "0.0", exponent, 1.0, 0.0);
 }
 
 void Units::addUnit(const std::string &name)
 {
-    addUnit(name, 0.0, 1.0, 1.0, 0.0);
-
+    addUnit(name, "0.0", 1.0, 1.0, 0.0);
 }
 
 void Units::setSourceUnits(const ImportPtr &imp, const std::string &name)

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #include "libcellml/units.h"
 
+#include <assert.h>
 #include <map>
 #include <sstream>
 #include <vector>
@@ -203,6 +204,7 @@ void Units::addUnit(const std::string &name, PREFIXES prefix, double exponent,
              double multiplier, double offset)
 {
     auto search = prefixToString.find(prefix);
+    assert(search != prefixToString.end());
     const std::string prefixString = search->second;
     addUnit(name, prefixString, exponent, multiplier, offset);
 }

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -17,8 +17,6 @@ limitations under the License.
 
 #include <map>
 #include <sstream>
-#include <stdexcept>
-#include <string>
 #include <vector>
 
 #include "libcellml/import.h"

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -29,7 +29,7 @@ namespace libcellml {
  * @param prefix The prefix to convert.
  * @return A std::string form of the given prefix.
  */
-EXPORT_FOR_TESTING std::string prefixToString(PREFIXES prefix);
+std::string prefixToString(PREFIXES prefix);
 
 /**
  * @brief The Unit struct.
@@ -39,9 +39,8 @@ EXPORT_FOR_TESTING std::string prefixToString(PREFIXES prefix);
  */
 struct Unit
 {
-    std::string mUnits = ""; /**< Name for the unit.*/
-    int mPrefixInt = 0; /**< Integer expression of the prefix for the unit.*/
-    PREFIXES mPrefixEnum = PREFIX_UNIT; /**< Enum expression of the prefix for the unit.*/
+    std::string mUnits; /**< Name for the unit.*/
+    std::string mPrefix = "0.0"; /**< String expression of the prefix for the unit.*/
     double mExponent = 1.0; /**< Exponent for the unit.*/
     double mMultiplier = 1.0; /**< Multiplier for the unit.*/
     double mOffset = 0.0; /**< Offset for the unit.*/
@@ -128,12 +127,8 @@ std::string Units::doSerialisation(FORMATS format) const
                             strs << u.mOffset;
                             repr += " offset=\"" + strs.str() + "\"";
                         }
-                        if (u.mPrefixEnum != PREFIX_UNIT) {
-                            repr += " prefix=\"" + prefixToString(u.mPrefixEnum) + "\"";
-                        } else if (u.mPrefixInt != 0) {
-                            std::ostringstream strs;
-                            strs << u.mPrefixInt;
-                            repr += " prefix=\"" + strs.str() + "\"";
+                        if (u.mPrefix != "0.0") {
+                            repr += " prefix=\"" + u.mPrefix + "\"";
                         }
                         repr += " units=\"" + u.mUnits + "\"";
                         repr += "/>";
@@ -162,7 +157,7 @@ void Units::addUnit(const std::string & units, PREFIXES prefix, double exponent,
 {
     Unit u;
     u.mUnits = units;
-    u.mPrefixEnum = prefix;
+    u.mPrefix = prefixToString(prefix);
     u.mExponent = exponent;
     u.mMultiplier = multiplier;
     u.mOffset = offset;
@@ -170,12 +165,16 @@ void Units::addUnit(const std::string & units, PREFIXES prefix, double exponent,
     mPimpl->mUnits.push_back(u);
 }
 
-void Units::addUnit(const std::string & units, int prefix, double exponent,
+void Units::addUnit(const std::string & units, double prefix, double exponent,
              double multiplier, double offset)
 {
     Unit u;
+    std::ostringstream strs;
     u.mUnits = units;
-    u.mPrefixInt = prefix;
+    if (prefix != 0.0) {
+        strs << prefix;
+        u.mPrefix = strs.str();
+    }
     u.mExponent = exponent;
     u.mMultiplier = multiplier;
     u.mOffset = offset;
@@ -185,12 +184,12 @@ void Units::addUnit(const std::string & units, int prefix, double exponent,
 
 void Units::addUnit(const std::string &units, double exponent)
 {
-    addUnit(units, PREFIX_UNIT, exponent, 1.0, 0.0);
+    addUnit(units, 0.0, exponent, 1.0, 0.0);
 }
 
 void Units::addUnit(const std::string &units)
 {
-    addUnit(units, PREFIX_UNIT, 1.0, 1.0, 0.0);
+    addUnit(units, 0.0, 1.0, 1.0, 0.0);
 
 }
 
@@ -266,12 +265,6 @@ EXPORT_FOR_TESTING std::string prefixToString(PREFIXES prefix)
     }
     case PREFIX_TERA: {
         str = "tera";
-        break;
-    }
-    case PREFIX_UNIT: {
-        /* Should not ask for the string version of this.
-        With the current codebase there is no way to trigger this case. */
-        str = "";
         break;
     }
     case PREFIX_YOCTO: {

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -40,10 +40,10 @@ std::string prefixToString(PREFIXES prefix);
 struct Unit
 {
     std::string mName; /**< Name for the unit.*/
-    std::string mPrefix = "0.0"; /**< String expression of the prefix for the unit.*/
-    double mExponent = 1.0; /**< Exponent for the unit.*/
-    double mMultiplier = 1.0; /**< Multiplier for the unit.*/
-    double mOffset = 0.0; /**< Offset for the unit.*/
+    std::string mPrefix; /**< String expression of the prefix for the unit.*/
+    std::string mExponent; /**< Exponent for the unit.*/
+    std::string mMultiplier; /**< Multiplier for the unit.*/
+    std::string mOffset; /**< Offset for the unit.*/
 };
 
 /**
@@ -112,22 +112,16 @@ std::string Units::doSerialisation(FORMATS format) const
                     for (std::vector<Unit>::size_type i = 0; i != mPimpl->mUnits.size(); ++i) {
                         repr += "<unit";
                         Unit u = mPimpl->mUnits[i];
-                        if (u.mExponent != 1.0) {
-                            std::ostringstream strs;
-                            strs << u.mExponent;
-                            repr += " exponent=\"" + strs.str() + "\"";
+                        if (u.mExponent.length()) {
+                            repr += " exponent=\"" + u.mExponent + "\"";
                         }
-                        if (u.mMultiplier != 1.0) {
-                            std::ostringstream strs;
-                            strs << u.mMultiplier;
-                            repr += " multiplier=\"" + strs.str() + "\"";
+                        if (u.mMultiplier.length()) {
+                            repr += " multiplier=\"" + u.mMultiplier + "\"";
                         }
-                        if (u.mOffset != 0.0) {
-                            std::ostringstream strs;
-                            strs << u.mOffset;
-                            repr += " offset=\"" + strs.str() + "\"";
+                        if (u.mOffset.length()) {
+                            repr += " offset=\"" + u.mOffset + "\"";
                         }
-                        if (u.mPrefix != "0.0") {
+                        if (u.mPrefix.length()) {
                             repr += " prefix=\"" + u.mPrefix + "\"";
                         }
                         repr += " units=\"" + u.mName + "\"";
@@ -158,10 +152,21 @@ void Units::addUnit(const std::string &name, PREFIXES prefix, double exponent,
     Unit u;
     u.mName = name;
     u.mPrefix = prefixToString(prefix);
-    u.mExponent = exponent;
-    u.mMultiplier = multiplier;
-    u.mOffset = offset;
-
+    if (exponent != 1.0) {
+        std::ostringstream strs;
+        strs << exponent;
+        u.mExponent = strs.str();
+    }
+    if (multiplier != 1.0) {
+        std::ostringstream strs;
+        strs << multiplier;
+        u.mMultiplier = strs.str();
+    }
+    if (offset != 0.0) {
+        std::ostringstream strs;
+        strs << offset;
+        u.mOffset = strs.str();
+    }
     mPimpl->mUnits.push_back(u);
 }
 
@@ -169,16 +174,27 @@ void Units::addUnit(const std::string &name, double prefix, double exponent,
              double multiplier, double offset)
 {
     Unit u;
-    std::ostringstream strs;
     u.mName = name;
     if (prefix != 0.0) {
+        std::ostringstream strs;
         strs << prefix;
         u.mPrefix = strs.str();
     }
-    u.mExponent = exponent;
-    u.mMultiplier = multiplier;
-    u.mOffset = offset;
-
+    if (exponent != 1.0) {
+        std::ostringstream strs;
+        strs << exponent;
+        u.mExponent = strs.str();
+    }
+    if (multiplier != 1.0) {
+        std::ostringstream strs;
+        strs << multiplier;
+        u.mMultiplier = strs.str();
+    }
+    if (offset != 0.0) {
+        std::ostringstream strs;
+        strs << offset;
+        u.mOffset = strs.str();
+    }
     mPimpl->mUnits.push_back(u);
 }
 
@@ -199,7 +215,7 @@ void Units::setSourceUnits(const ImportPtr &imp, const std::string &name)
     setImportReference(name);
 }
 
-EXPORT_FOR_TESTING std::string prefixToString(PREFIXES prefix)
+std::string prefixToString(PREFIXES prefix)
 {
     std::string str = "";
     switch (prefix) {

--- a/tests/coverage/coverage.cpp
+++ b/tests/coverage/coverage.cpp
@@ -87,7 +87,6 @@ TEST(Coverage, prefixToString) {
          "peta",
          "pico",
          "tera",
-         "unit",
          "yocto",
          "yotta",
          "zepto",
@@ -145,7 +144,6 @@ TEST(Coverage, variable) {
 namespace libcellml {
 
 std::string interfaceTypeToString(Variable::INTERFACE_TYPES interfaceType);
-std::string prefixToString(PREFIXES prefix);
 
 }
 

--- a/tests/coverage/coverage.cpp
+++ b/tests/coverage/coverage.cpp
@@ -110,7 +110,6 @@ TEST(Coverage, prefixToString) {
          libcellml::PREFIX_PETA,
          libcellml::PREFIX_PICO,
          libcellml::PREFIX_TERA,
-         libcellml::PREFIX_UNIT,
          libcellml::PREFIX_YOCTO,
          libcellml::PREFIX_YOTTA,
          libcellml::PREFIX_ZEPTO,
@@ -153,9 +152,4 @@ std::string prefixToString(PREFIXES prefix);
 TEST(Coverage, interfaceTypeToStringNone) {
     std::string s = libcellml::interfaceTypeToString(libcellml::Variable::INTERFACE_TYPE_NONE);
     EXPECT_EQ("none",s);
-}
-
-TEST(Coverage, prefixTypeToStringUnit) {
-    std::string s = libcellml::prefixToString(libcellml::PREFIX_UNIT);
-    EXPECT_EQ("",s);
 }

--- a/tests/model/units_import.cpp
+++ b/tests/model/units_import.cpp
@@ -170,13 +170,13 @@ TEST(UnitsImport, importModify) {
 
     libcellml::UnitsPtr importedUnitsMultiplied = std::make_shared<libcellml::Units>();
     importedUnitsMultiplied->setName("multiplied_import");
-    importedUnitsMultiplied->addUnit("units_in_this_model", libcellml::PREFIX_UNIT, 1.0, 5.6);
+    importedUnitsMultiplied->addUnit("units_in_this_model", 0.0, 1.0, 5.6);
 
     m.addUnits(importedUnitsMultiplied);
 
     libcellml::UnitsPtr importedUnitsOffset = std::make_shared<libcellml::Units>();
     importedUnitsOffset->setName("offset_import");
-    importedUnitsOffset->addUnit("units_in_this_model", libcellml::PREFIX_UNIT, 1.0, 1.0, 76);
+    importedUnitsOffset->addUnit("units_in_this_model", 0, 1.0, 1.0, 76);
 
     m.addUnits(importedUnitsOffset);
 

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -90,7 +90,7 @@ TEST(Units, compoundUnitsRaw) {
     libcellml::UnitsPtr u = std::make_shared<libcellml::Units>();
     u->setName("compound_unit");
 
-    u->addUnit("ampere", -6);
+    u->addUnit("ampere", -6, 1.0);
     u->addUnit("kelvin");
     u->addUnit("siemens", -3, -1.0);
 

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -126,6 +126,32 @@ TEST(Units, compoundUnitsUsingDefines) {
     EXPECT_EQ(e, a);
 }
 
+TEST(Units, compoundUnitsUsingDefinesStringPrefixes) {
+    const std::string e =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            "<model xmlns=\"http://www.cellml.org/cellml/1.2#\">"
+            "<units name=\"compound_unit\">"
+            "<unit prefix=\"micro\" units=\"ampere\"/>"
+            "<unit units=\"kelvin\"/>"
+            "<unit exponent=\"-1\" prefix=\"milli\" units=\"siemens\"/>"
+            "</units>"
+            "</model>";
+
+    libcellml::Model m;
+
+    libcellml::UnitsPtr u = std::make_shared<libcellml::Units>();
+    u->setName("compound_unit");
+
+    u->addUnit(libcellml::STANDARD_UNIT_AMPERE, "micro");
+    u->addUnit(libcellml::STANDARD_UNIT_KELVIN);
+    u->addUnit(libcellml::STANDARD_UNIT_SIEMENS, "milli", -1.0);
+
+    m.addUnits(u);
+
+    std::string a = m.serialise(libcellml::FORMAT_XML);
+    EXPECT_EQ(e, a);
+}
+
 TEST(Units, multiply) {
     const std::string e =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -134,6 +134,7 @@ TEST(Units, compoundUnitsUsingDefinesAndStringUnitsAndPrefixes) {
             "<unit prefix=\"micro\" units=\"ampere\"/>"
             "<unit units=\"kelvin\"/>"
             "<unit exponent=\"-1\" prefix=\"milli\" units=\"siemens\"/>"
+            "<unit prefix=\"1.7e310\" units=\"meter\"/>"
             "</units>"
             "</model>";
 
@@ -145,6 +146,7 @@ TEST(Units, compoundUnitsUsingDefinesAndStringUnitsAndPrefixes) {
     u->addUnit(libcellml::STANDARD_UNIT_AMPERE, "micro");
     u->addUnit("kelvin");
     u->addUnit("siemens", "milli", -1.0);
+    u->addUnit("meter", "1.7e310");
 
     m.addUnits(u);
 

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -126,7 +126,7 @@ TEST(Units, compoundUnitsUsingDefines) {
     EXPECT_EQ(e, a);
 }
 
-TEST(Units, compoundUnitsUsingDefinesStringPrefixes) {
+TEST(Units, compoundUnitsUsingDefinesAndStringUnitsAndPrefixes) {
     const std::string e =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
             "<model xmlns=\"http://www.cellml.org/cellml/1.2#\">"
@@ -143,8 +143,8 @@ TEST(Units, compoundUnitsUsingDefinesStringPrefixes) {
     u->setName("compound_unit");
 
     u->addUnit(libcellml::STANDARD_UNIT_AMPERE, "micro");
-    u->addUnit(libcellml::STANDARD_UNIT_KELVIN);
-    u->addUnit(libcellml::STANDARD_UNIT_SIEMENS, "milli", -1.0);
+    u->addUnit("kelvin");
+    u->addUnit("siemens", "milli", -1.0);
 
     m.addUnits(u);
 

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -205,7 +205,7 @@ TEST(Units, farhenheit) {
     u->setName("fahrenheit");
 
     /* Give prefix and exponent their default values. */
-    u->addUnit(libcellml::STANDARD_UNIT_CELSIUS, libcellml::PREFIX_UNIT, 1.0, 1.8, 32.0);
+    u->addUnit(libcellml::STANDARD_UNIT_CELSIUS, 0.0, 1.0, 1.8, 32.0);
     m.addUnits(u);
 
     std::string a = m.serialise(libcellml::FORMAT_XML);
@@ -232,7 +232,7 @@ TEST(Units, multiple) {
     u1->setName("fahrenheit");
 
     /* Give prefix and exponent their default values. */
-    u1->addUnit(libcellml::STANDARD_UNIT_CELSIUS, libcellml::PREFIX_UNIT, 1.0, 1.8, 32.0);
+    u1->addUnit(libcellml::STANDARD_UNIT_CELSIUS, 0, 1.0, 1.8, 32.0);
 
     libcellml::UnitsPtr u2 = std::make_shared<libcellml::Units>();
     u2->setName("metres_per_second");


### PR DESCRIPTION
This implements and tests changes to internal handling of units:
- Removes `PREFIX_UNIT`
- Replaces `mPrefixEnum` and `mPrefixInt` with `mPrefix` (string)
- Replaces `switch`-based handling of `prefixToString()` with a `map`
- All `struct Unit` members now stored as strings
- `Unit::mUnits` changed to `Unit::mName` 

Changes since last round of comments:
- Removed prefix exception handling (now serialises all non-zero user-specified prefix strings). This can be re-added when we get to the validation step and formalise our error/exception handling.
- Included an assert check for prefixToString search.

Addresses issue #86
