### PR TITLE
Add annotation 'id's for libCellML entities

### DIFF
--- a/src/api/libcellml/entity.h
+++ b/src/api/libcellml/entity.h
@@ -49,6 +49,29 @@ public:
     std::string serialise(Format format) const;
 
     /**
+     * @brief Set the @p id document identifier for this entity.
+     *
+     * Set the @p id document identifier for this entity using a @c std::string.
+     *
+     * @sa getId
+     *
+     * @param id The @c std::string document identifier to set.
+     */
+    void setId(const std::string &id);
+
+    /**
+     * @brief Get the document identifier for this entity.
+     *
+     * Get the string corresponding with the @c id document identifier for this variable.
+     * If no @c id has been set, returns an empty string.
+     *
+     * @sa setId
+     *
+     * @return The @c std::string document identifier for this object
+     */
+    std::string getId() const;
+
+    /**
      * @brief Returns the parent of the CellML Entity.
      *
      * @return A pointer to the entities parent if it has one,
@@ -114,6 +137,7 @@ private:
 
     Model *mParentModel; /**< Pointer to parent model. */
     Component *mParentComponent; /**< Pointer to component model. */
+    std::string mId; /**< String document identifier for this entity. */
 };
 
 }

--- a/src/api/libcellml/entity.h
+++ b/src/api/libcellml/entity.h
@@ -62,12 +62,12 @@ public:
     /**
      * @brief Get the document identifier for this entity.
      *
-     * Get the string corresponding with the @c id document identifier for this variable.
+     * Get the string corresponding with the @c id document identifier for this entity.
      * If no @c id has been set, returns an empty string.
      *
      * @sa setId
      *
-     * @return The @c std::string document identifier for this object
+     * @return The @c std::string document identifier for this entity.
      */
     std::string getId() const;
 

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -192,6 +192,9 @@ std::string Component::doSerialisation(Format format) const
         if (componentName.length()) {
             repr += " name=\"" + componentName + "\"";
         }
+        if (getId().length()) {
+            repr += " id=\"" + getId() + "\"";
+        }
         if (variableCount() > 0) {
             endTag = true;
             repr += ">";

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -24,7 +24,6 @@ namespace libcellml {
 Entity::Entity()
     : mParentModel(nullptr)
     , mParentComponent(nullptr)
-    , mId("")
 {
 }
 

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -24,6 +24,7 @@ namespace libcellml {
 Entity::Entity()
     : mParentModel(nullptr)
     , mParentComponent(nullptr)
+    , mId("")
 {
 }
 
@@ -35,12 +36,14 @@ Entity::Entity(const Entity& rhs)
 {
     mParentComponent = rhs.mParentComponent;
     mParentModel = rhs.mParentModel;
+    mId = rhs.mId;
 }
 
 Entity::Entity(Entity &&rhs)
 {
     mParentComponent = std::move(rhs.mParentComponent);
     mParentModel = std::move(rhs.mParentModel);
+    mId = std::move(rhs.mId);
 }
 
 Entity& Entity::operator=(Entity e)
@@ -53,6 +56,7 @@ void Entity::swap(Entity &rhs)
 {
     std::swap(this->mParentComponent, rhs.mParentComponent);
     std::swap(this->mParentModel, rhs.mParentModel);
+    std::swap(this->mId, rhs.mId);
 }
 
 std::string Entity::doSerialisation(Format /* format */) const
@@ -63,6 +67,16 @@ std::string Entity::doSerialisation(Format /* format */) const
 std::string Entity::serialise(Format format) const
 {
     return doSerialisation(format);
+}
+
+void Entity::setId(const std::string &id)
+{
+    mId = id;
+}
+
+std::string Entity::getId() const
+{
+    return mId;
 }
 
 void *Entity::getParent() const {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -127,6 +127,9 @@ std::string Model::doSerialisation(Format format) const
         if (getName().length()) {
             repr += " name=\"" + getName() + "\"";
         }
+        if (getId().length()) {
+            repr += " id=\"" + getId() + "\"";
+        }
         bool endTag = false;
         if ((importMap.size() > 0) || (componentCount() > 0) || (unitsCount() > 0)){
             endTag = true;

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -131,12 +131,21 @@ std::string Units::doSerialisation(Format format) const
     if (format == Format::XML) {
         if (getName().length()) {
             if (isImport()) {
-                repr += "<import xlink:href=\"" + getImport()->getSource() + "\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">"
-                        "<units units_ref=\"" + getImportReference() + "\" name=\"" + getName() + "\"/>"
-                        "</import>";
+                repr += "<import xlink:href=\"" + getImport()->getSource() + "\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"";
+                if (getImport()->getId().length()) {
+                    repr += " id=\"" + getImport()->getId() + "\"";
+                }
+                repr += "><units units_ref=\"" + getImportReference() + "\" name=\"" + getName() + "\"";
+                if (getId().length()) {
+                    repr += " id=\"" + getId() + "\"";
+                }
+                repr += "/></import>";
             } else {
                 bool endTag = false;
                 repr += "<units name=\"" + getName() + "\"";
+                if (getId().length()) {
+                    repr += " id=\"" + getId() + "\"";
+                }
                 if (isBaseUnit()) {
                     repr += " base_unit=\"yes\"";
                 } else if (mPimpl->mUnits.size() > 0) {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -159,6 +159,9 @@ std::string Variable::doSerialisation(Format format) const
         if (getName().length()) {
             repr += " name=\"" + getName() + "\"";
         }
+        if (getId().length()) {
+            repr += " id=\"" + getId() + "\"";
+        }
         if (getUnits()) {
             repr += " units=\"" + getUnits()->getName() + "\"";
         }

--- a/tests/model/model.cpp
+++ b/tests/model/model.cpp
@@ -376,3 +376,49 @@ TEST(Model, constructors) {
     EXPECT_EQ("", m2.getName());
 
 }
+
+TEST(Model, setAndCheckIdsAllEntities) {
+    const std::string expected =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            "<model xmlns=\"http://www.cellml.org/cellml/1.2#\" name=\"mname\" id=\"mid\">"
+              "<import xlink:href=\"some-other-model.xml\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" id=\"iid\">"
+                "<units units_ref=\"a_units_in_that_model\" name=\"u1name\" id=\"u1id\"/>"
+              "</import>"
+              "<units name=\"u2name\" id=\"u2id\"/>"
+              "<component name=\"cname\" id=\"cid\">"
+                "<variable name=\"vname\" id=\"vid\" units=\"u1name\"/>"
+              "</component>"
+            "</model>";
+
+    libcellml::Model m;
+    libcellml::ImportPtr i = std::make_shared<libcellml::Import>();
+    libcellml::ComponentPtr c = std::make_shared<libcellml::Component>();
+    libcellml::VariablePtr v = std::make_shared<libcellml::Variable>();
+    libcellml::UnitsPtr u1 = std::make_shared<libcellml::Units>();
+    libcellml::UnitsPtr u2 = std::make_shared<libcellml::Units>();
+
+    i->setSource("some-other-model.xml");
+    u1->setSourceUnits(i, "a_units_in_that_model");
+
+    m.setName("mname");
+    c->setName("cname");
+    v->setName("vname");
+    u1->setName("u1name");
+    u2->setName("u2name");
+
+    m.setId("mid");
+    i->setId("iid");
+    c->setId("cid");
+    v->setId("vid");
+    u1->setId("u1id");
+    u2->setId("u2id");
+
+    v->setUnits(u1);
+    c->addVariable(v);
+    m.addUnits(u1);
+    m.addUnits(u2);
+    m.addComponent(c);
+
+    std::string actual = m.serialise(libcellml::Format::XML);
+    EXPECT_EQ(expected, actual);
+}

--- a/tests/model/model.cpp
+++ b/tests/model/model.cpp
@@ -27,6 +27,13 @@ TEST(Model, serialise) {
     EXPECT_EQ(e, a);
 }
 
+TEST(Model, setGetId) {
+    const std::string id = "modelID";
+    libcellml::Model m;
+    m.setId(id);
+    EXPECT_EQ(id, m.getId());
+}
+
 TEST(Model, serialiseAllocatePointer) {
     const std::string e = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<model xmlns=\"http://www.cellml.org/cellml/1.2#\"/>";
     libcellml::Model* m = new libcellml::Model();
@@ -369,4 +376,3 @@ TEST(Model, constructors) {
     EXPECT_EQ("", m2.getName());
 
 }
-


### PR DESCRIPTION
Following the discussion in #123, this adds basic support for `get/setId()` on libCellML entities and serialisation of these entities.

A few serialisation cases have been intentionally left out of this pull- for example setting the `id` on units within components. These rely on features like `ComponentEntity::getUnits()` introduced in #114 and will be picked up there. 
