### PR TITLE
Rename generated header files.  

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 include(GenerateExportHeader)
 
+set(CLEAN_FILES)
+
 foreach(VERSION_PART libCellML_VERSION_MAJOR libCellML_VERSION_MINOR libCellML_VERSION_PATCH)
   string(LENGTH ${${VERSION_PART}} VERSION_PART_LENGTH)
   if(VERSION_PART_LENGTH EQUAL 1)
@@ -23,13 +25,15 @@ endforeach()
 set(LIBCELLML_LIBRARY_VERSION 0x${libCellML_VERSION_MAJOR_PAD}${libCellML_VERSION_MAJOR}${libCellML_VERSION_MINOR_PAD}${libCellML_VERSION_MINOR}${libCellML_VERSION_PATCH_PAD}${libCellML_VERSION_PATCH})
 set(LIBCELLML_LIBRARY_VERSION_STRING "${libCellML_VERSION_MAJOR}.${libCellML_VERSION_MINOR}.${libCellML_VERSION_PATCH}")
 
-set(CELLML_EXPORT_H "${CMAKE_CURRENT_BINARY_DIR}/api/libcellml/libcellml_export.h")
-set_source_files_properties(${CELLML_EXPORT_H} PROPERTIES GENERATED TRUE)
-set(LIBCELLML_CONFIG_H "${CMAKE_CURRENT_BINARY_DIR}/libcellml_config.h")
+set(LIBCELLML_EXPORTDEFINITIONS_H "${CMAKE_CURRENT_BINARY_DIR}/api/libcellml/exportdefinitions.h")
+set_source_files_properties(${LIBCELLML_EXPORTDEFINITIONS_H} PROPERTIES GENERATED TRUE)
+set(LIBCELLML_VERSIONCONFIG_H "${CMAKE_CURRENT_BINARY_DIR}/versionconfig.h")
 configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/configure/libcellml_config.h.in"
-  ${LIBCELLML_CONFIG_H}
+  "${CMAKE_CURRENT_SOURCE_DIR}/configure/versionconfig.h.in"
+  ${LIBCELLML_VERSIONCONFIG_H}
 )
+
+list(APPEND CLEAN_FILES ${LIBCELLML_VERSIONCONFIG_H} ${LIBCELLML_EXPORTDEFINITIONS_H})
 
 set(SOURCE_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/component.cpp
@@ -66,12 +70,12 @@ set(API_HEADER_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/api/libcellml/units.h
   ${CMAKE_CURRENT_SOURCE_DIR}/api/libcellml/variable.h
   ${CMAKE_CURRENT_SOURCE_DIR}/api/libcellml/version.h
-  ${CELLML_EXPORT_H}
+  ${LIBCELLML_EXPORTDEFINITIONS_H}
   ${CMAKE_CURRENT_SOURCE_DIR}/api/libcellml/module/libcellml
 )
 
 set(HEADER_FILES
-  ${LIBCELLML_CONFIG_H}
+  ${LIBCELLML_VERSIONCONFIG_H}
   ${CMAKE_CURRENT_SOURCE_DIR}/xmlattribute.h
   ${CMAKE_CURRENT_SOURCE_DIR}/xmldoc.h
   ${CMAKE_CURRENT_SOURCE_DIR}/xmlnode.h
@@ -92,7 +96,7 @@ add_library(cellml
   ${API_HEADER_FILES}
 )
 
-generate_export_header(cellml EXPORT_FILE_NAME ${CELLML_EXPORT_H} BASE_NAME LIBCELLML)
+generate_export_header(cellml EXPORT_FILE_NAME ${LIBCELLML_EXPORTDEFINITIONS_H} BASE_NAME LIBCELLML)
 
 target_include_directories(cellml
   PUBLIC
@@ -163,4 +167,7 @@ install(FILES
 )
 
 install(EXPORT libcellml-targets DESTINATION lib/cmake)
+
+list(APPEND CLEAN_FILES libcellml-exports.cmake)
+set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${CLEAN_FILES}")
 

--- a/src/api/libcellml/component.h
+++ b/src/api/libcellml/component.h
@@ -18,7 +18,7 @@ limitations under the License.
 #define LIBCELLML_LIBCELLML_COMPONENT_H
 
 #include "libcellml/componententity.h"
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 
 namespace libcellml {
 

--- a/src/api/libcellml/componententity.h
+++ b/src/api/libcellml/componententity.h
@@ -18,7 +18,7 @@ limitations under the License.
 #define LIBCELLML_LIBCELLML_COMPONENTENTITY_H
 
 #include "libcellml/importedentity.h"
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/types.h"
 
 namespace libcellml {

--- a/src/api/libcellml/entity.h
+++ b/src/api/libcellml/entity.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <string>
 
 #include "libcellml/enumerations.h"
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/types.h"
 
 namespace libcellml {

--- a/src/api/libcellml/error.h
+++ b/src/api/libcellml/error.h
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include <string>
 
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/types.h"
 
 namespace libcellml {

--- a/src/api/libcellml/import.h
+++ b/src/api/libcellml/import.h
@@ -17,7 +17,7 @@ limitations under the License.
 #ifndef LIBCELLML_LIBCELLML_IMPORT_H_
 #define LIBCELLML_LIBCELLML_IMPORT_H_
 
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/namedentity.h"
 
 namespace libcellml {

--- a/src/api/libcellml/importedentity.h
+++ b/src/api/libcellml/importedentity.h
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include <string>
 
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/namedentity.h"
 #include "libcellml/types.h"
 

--- a/src/api/libcellml/logger.h
+++ b/src/api/libcellml/logger.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <string>
 
 #include "libcellml/error.h"
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/types.h"
 
 namespace libcellml {

--- a/src/api/libcellml/model.h
+++ b/src/api/libcellml/model.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <string>
 
 #include "libcellml/componententity.h"
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 
 //! Everything in libCellML is in this namespace.
 namespace libcellml {

--- a/src/api/libcellml/namedentity.h
+++ b/src/api/libcellml/namedentity.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <string>
 
 #include "libcellml/entity.h"
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/types.h"
 
 namespace libcellml {

--- a/src/api/libcellml/units.h
+++ b/src/api/libcellml/units.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <string>
 
 #include "libcellml/importedentity.h"
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/types.h"
 
 namespace libcellml {

--- a/src/api/libcellml/variable.h
+++ b/src/api/libcellml/variable.h
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include <string>
 
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 #include "libcellml/namedentity.h"
 #include "libcellml/types.h"
 

--- a/src/api/libcellml/version.h
+++ b/src/api/libcellml/version.h
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include <string>
 
-#include "libcellml/libcellml_export.h"
+#include "libcellml/exportdefinitions.h"
 
 //! Everything in libCellML is in this namespace.
 namespace libcellml {

--- a/src/configure/versionconfig.h.in
+++ b/src/configure/versionconfig.h.in
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef LIBCELLML_LIBCELLML_CONFIG_H
-#define LIBCELLML_LIBCELLML_CONFIG_H
+#ifndef LIBCELLML_LIBCELLML_VERSIONCONFIG_H
+#define LIBCELLML_LIBCELLML_VERSIONCONFIG_H
 
 #include <string>
 
@@ -30,4 +30,4 @@ static const std::string LIBCELLML_LIBRARY_VERSION_STRING="@LIBCELLML_LIBRARY_VE
 
 }
 
-#endif /* LIBCELLML_LIBCELLML_CONFIG_H */
+#endif /* LIBCELLML_LIBCELLML_VERSIONCONFIG_H */

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include <string>
 
-#include "libcellml_config.h"
+#include "versionconfig.h"
 
 namespace libcellml {
 


### PR DESCRIPTION
Rename libcellml_export.h to exportdefinitions.h. Rename libcellml_config.h to versionconfig.h.
This pull request addresses issue #43.
