### PR TITLE
Tidy up header file includes to the correct order.

### DIFF
--- a/src/api/libcellml/componententity.h
+++ b/src/api/libcellml/componententity.h
@@ -16,8 +16,8 @@ limitations under the License.
 
 #pragma once
 
-#include "libcellml/importedentity.h"
 #include "libcellml/exportdefinitions.h"
+#include "libcellml/importedentity.h"
 #include "libcellml/types.h"
 
 namespace libcellml {

--- a/src/api/libcellml/units.h
+++ b/src/api/libcellml/units.h
@@ -19,8 +19,8 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "libcellml/importedentity.h"
 #include "libcellml/exportdefinitions.h"
+#include "libcellml/importedentity.h"
 #include "libcellml/types.h"
 
 namespace libcellml { 

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 #include "libcellml/error.h"
 
 #include <map>

--- a/src/importedentity.cpp
+++ b/src/importedentity.cpp
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 #include "libcellml/importedentity.h"
 
 namespace libcellml {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -17,9 +17,9 @@ limitations under the License.
 #include "libcellml/model.h"
 
 #include <map>
+#include <stack>
 #include <utility>
 #include <vector>
-#include <stack>
 
 #include "libcellml/component.h"
 #include "libcellml/import.h"

--- a/src/namedentity.cpp
+++ b/src/namedentity.cpp
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 #include "libcellml/namedentity.h"
 
 #include "libcellml/component.h"

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 #include "libcellml/units.h"
 
 #include <algorithm>

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 #include "libcellml/variable.h"
 
 #include <algorithm>

--- a/src/xmlattribute.cpp
+++ b/src/xmlattribute.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "xmlattribute.h"
 
 #include <string>
+
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 

--- a/src/xmlattribute.cpp
+++ b/src/xmlattribute.cpp
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "xmlattribute.h"
+
+#include <string>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <string>
-
-#include "xmlattribute.h"
 
 namespace libcellml {
 

--- a/src/xmldoc.cpp
+++ b/src/xmldoc.cpp
@@ -17,11 +17,11 @@ limitations under the License.
 #include "xmldoc.h"
 
 #include <cstring>
+#include <string>
+#include <vector>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xmlerror.h>
-#include <string>
-#include <vector>
 
 #include "mathml_config.h"
 #include "xmlnode.h"

--- a/src/xmldoc.cpp
+++ b/src/xmldoc.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstring>
 #include <string>
 #include <vector>
+
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xmlerror.h>

--- a/src/xmlnode.cpp
+++ b/src/xmlnode.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "xmlnode.h"
 
 #include <string>
+
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 

--- a/src/xmlnode.cpp
+++ b/src/xmlnode.cpp
@@ -16,9 +16,9 @@ limitations under the License.
 
 #include "xmlnode.h"
 
+#include <string>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <string>
 
 #include "xmlattribute.h"
 


### PR DESCRIPTION
Addressing part of issue #116 (although not in the checkbox list).

Example ordering for header includes:

```
// First header file is the corresponding header file for the current implementation
// file in this case validator.cpp
#include "libcellml/validator.h"

// Second section of header files is a list of all system header files required in alphabetical
// order, compound header files coming at the end.
#include <algorithm>
#include <map>
#include <sstream>
#include <string>
#include <vector>
#include <libxml/parser.h>
#include <libxml/tree.h>

// Third section of header files is a list of all local project header files required in alphabetical 
// order.
#include "libcellml/component.h"
#include "libcellml/import.h"
#include "libcellml/error.h"
#include "libcellml/model.h"
#include "libcellml/units.h"
#include "libcellml/variable.h"
#include "xmldoc.h"
```
