### PR TITLE
New test case with complex encapsulation hierarchy.

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -913,18 +913,21 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
         // Get first child of this parent component_ref.
         XmlNodePtr childComponentNode = parentComponentNode->getFirstChild();
         if (!childComponentNode) {
-            ErrorPtr err = std::make_shared<Error>();
-            if (parentComponent) {
-                err->setDescription("Encapsulation in model '" + model->getName() +
-                                    "' specifies '" + parentComponent->getName() +
-                                    "' as a parent component_ref but it does not have any children.");
-            } else {
-                err->setDescription("Encapsulation in model '" + model->getName() +
-                                    "' specifies an invalid parent component_ref that also does not have any children.");
+            XmlNodePtr grandParentComponentNode = parentComponentNode->getParent();
+            if (grandParentComponentNode->getType() == "encapsulation") {
+                ErrorPtr err = std::make_shared<Error>();
+                if (parentComponent) {
+                    err->setDescription("Encapsulation in model '" + model->getName() +
+                                        "' specifies '" + parentComponent->getName() +
+                                        "' as a parent component_ref but it does not have any children.");
+                } else {
+                    err->setDescription("Encapsulation in model '" + model->getName() +
+                                        "' specifies an invalid parent component_ref that also does not have any children.");
+                }
+                err->setModel(model);
+                err->setKind(Error::Kind::ENCAPSULATION);
+                mParser->addError(err);
             }
-            err->setModel(model);
-            err->setKind(Error::Kind::ENCAPSULATION);
-            mParser->addError(err);
         }
 
         // Loop over encapsulated children.

--- a/tests/parser/file_parser.cpp
+++ b/tests/parser/file_parser.cpp
@@ -95,3 +95,18 @@ TEST(Parser, parseOrdModelFromFile) {
     EXPECT_EQ("public", a);
 }
 
+TEST(Parser, parseComplexEncapsulationModelFromFile) {
+    std::ifstream t(TestResources::getLocation(
+                    TestResources::CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE));
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+
+    libcellml::Parser p(libcellml::Format::XML);
+    p.parseModel(buffer.str());
+
+    EXPECT_EQ(0, p.errorCount());
+    for (size_t i = 0; i < p.errorCount(); ++i) {
+        std::cout << p.getError(i)->getDescription() << std::endl;
+    }
+}
+

--- a/tests/parser/file_parser.cpp
+++ b/tests/parser/file_parser.cpp
@@ -96,6 +96,7 @@ TEST(Parser, parseOrdModelFromFile) {
 }
 
 TEST(Parser, parseComplexEncapsulationModelFromFile) {
+    // This test resulted from https://github.com/cellml/libcellml/issues/170
     std::ifstream t(TestResources::getLocation(
                     TestResources::CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE));
     std::stringstream buffer;
@@ -105,8 +106,5 @@ TEST(Parser, parseComplexEncapsulationModelFromFile) {
     p.parseModel(buffer.str());
 
     EXPECT_EQ(0, p.errorCount());
-    for (size_t i = 0; i < p.errorCount(); ++i) {
-        std::cout << p.getError(i)->getDescription() << std::endl;
-    }
 }
 

--- a/tests/parser/tests.cmake
+++ b/tests/parser/tests.cmake
@@ -20,6 +20,7 @@ set(${CURRENT_TEST}_SRCS
 
 set(CELLML_SINE_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/sine_approximations.xml")
 set(CELLML_SINE_IMPORTS_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/sine_approximations_import.xml")
+set(CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/complex_encapsulation.xml")
 set(CELLML_ORD_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/Ohara_Rudy_2011.cellml")
 set(CELLML_INVALID_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/invalid_cellml_2.0.xml")
 

--- a/tests/resources/complex_encapsulation.xml
+++ b/tests/resources/complex_encapsulation.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model xmlns="http://www.cellml.org/cellml/2.0#" 
+	xmlns:cellml="http://www.cellml.org/cellml/2.0#" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	name="complex_encapsulation_example" 
+	id="complex_encpsulation_example_id">
+  <component name="root"/>
+  <component name="L1_c1"/>
+  <component name="L1_c2"/>
+  <component name="L1_c3"/>
+  <component name="L1_L2_c1"/>
+  <encapsulation>
+    <component_ref component="root">
+      <component_ref component="L1_c1">
+        <component_ref component="L1_L2_c1"/>
+      </component_ref>
+      <component_ref component="L1_c2"/>
+      <component_ref component="L1_c3"/>
+    </component_ref>
+  </encapsulation>
+</model>

--- a/tests/test_resources.h.in
+++ b/tests/test_resources.h.in
@@ -11,7 +11,8 @@ public:
         CELLML_INVALID_MODEL_RESOURCE = 1,
         CELLML_SINE_MODEL_RESOURCE = 2,
         CELLML_SINE_IMPORTS_MODEL_RESOURCE = 3,
-        CELLML_ORD_MODEL_RESOURCE = 4
+        CELLML_ORD_MODEL_RESOURCE = 4,
+        CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE = 5
     };
 
     TestResources()
@@ -29,6 +30,10 @@ public:
         if (resourceName == TestResources::CELLML_SINE_IMPORTS_MODEL_RESOURCE)
         {
             return "@CELLML_SINE_IMPORTS_MODEL_RESOURCE@";
+        }
+        if (resourceName == TestResources::CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE)
+        {
+            return "@CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE@";
         }
         if (resourceName == TestResources::CELLML_INVALID_MODEL_RESOURCE)
         {


### PR DESCRIPTION
As far as I can tell, this new test should parse fine, but the addition of the `L1_L2_c1` child into the
encapsulation hierarchy causes the parser to give a bogus error. Demonstrates the issue mentioned in #170.