### PR TITLE
adding test to illustrate #183.

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -351,7 +351,7 @@ void Parser::ParserImpl::loadComponent(const ComponentPtr &component, const XmlN
             // TODO: copy any namespaces declared in parents into the math element
             //       so math is a valid subdocument.
             std::string math = childNode->convertToString();
-            component->setMath(math);
+            component->appendMath(math);
         } else if (childNode->isType("text")) {
             std::string textNode = childNode->convertToString();
             // Ignore whitespace when parsing.

--- a/tests/parser/file_parser.cpp
+++ b/tests/parser/file_parser.cpp
@@ -110,6 +110,10 @@ TEST(Parser, parseComplexEncapsulationModelFromFile) {
 
 TEST(Parser, parseModelWithComponentsWithMultipleMathElements) {
     // This test resulted from https://github.com/cellml/libcellml/issues/183
+
+    std::string e1 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>a1</ci>\n\t\t\t\t<apply><plus/>\n\t\t\t\t\t<ci>b1</ci>\n\t\t\t\t\t<ci>c1</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math>";
+    std::string e2 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>b2</ci>\n\t\t\t\t<apply><times/>\n\t\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\">2.0</cn>\n\t\t\t\t\t<ci>d</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math>\n\t\t<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>d</ci>\n\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\" type=\"e-notation\">0.5<sep/>1</cn>\n\t\t\t</apply>\n\t\t</math>";
+
     std::ifstream t(TestResources::getLocation(
                     TestResources::CELLML_A_PLUS_B_MODEL_RESOURCE));
     std::stringstream buffer;
@@ -118,9 +122,6 @@ TEST(Parser, parseModelWithComponentsWithMultipleMathElements) {
     libcellml::Parser p(libcellml::Format::XML);
     libcellml::ModelPtr model = p.parseModel(buffer.str());
     EXPECT_EQ(0, p.errorCount());
-
-    std::string e1 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>a1</ci>\n\t\t\t\t<apply><plus/>\n\t\t\t\t\t<ci>b1</ci>\n\t\t\t\t\t<ci>c1</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math>";
-    std::string e2 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>b2</ci>\n\t\t\t\t<apply><times/>\n\t\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\">2.0</cn>\n\t\t\t\t\t<ci>d</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math>\n\t\t<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>d</ci>\n\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\" type=\"e-notation\">0.5<sep/>1</cn>\n\t\t\t</apply>\n\t\t</math>";
 
     std::string a = model->getComponent("c1")->getMath();
     EXPECT_EQ(e1, a);

--- a/tests/parser/file_parser.cpp
+++ b/tests/parser/file_parser.cpp
@@ -112,7 +112,7 @@ TEST(Parser, parseModelWithComponentsWithMultipleMathElements) {
     // This test resulted from https://github.com/cellml/libcellml/issues/183
 
     std::string e1 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>a1</ci>\n\t\t\t\t<apply><plus/>\n\t\t\t\t\t<ci>b1</ci>\n\t\t\t\t\t<ci>c1</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math>";
-    std::string e2 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>b2</ci>\n\t\t\t\t<apply><times/>\n\t\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\">2.0</cn>\n\t\t\t\t\t<ci>d</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math>\n\t\t<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>d</ci>\n\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\" type=\"e-notation\">0.5<sep/>1</cn>\n\t\t\t</apply>\n\t\t</math>";
+    std::string e2 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>b2</ci>\n\t\t\t\t<apply><times/>\n\t\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\">2.0</cn>\n\t\t\t\t\t<ci>d</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math><math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>d</ci>\n\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\" type=\"e-notation\">0.5<sep/>1</cn>\n\t\t\t</apply>\n\t\t</math>";
 
     std::ifstream t(TestResources::getLocation(
                     TestResources::CELLML_A_PLUS_B_MODEL_RESOURCE));

--- a/tests/parser/file_parser.cpp
+++ b/tests/parser/file_parser.cpp
@@ -108,3 +108,24 @@ TEST(Parser, parseComplexEncapsulationModelFromFile) {
     EXPECT_EQ(0, p.errorCount());
 }
 
+TEST(Parser, parseModelWithComponentsWithMultipleMathElements) {
+    // This test resulted from https://github.com/cellml/libcellml/issues/183
+    std::ifstream t(TestResources::getLocation(
+                    TestResources::CELLML_A_PLUS_B_MODEL_RESOURCE));
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+
+    libcellml::Parser p(libcellml::Format::XML);
+    libcellml::ModelPtr model = p.parseModel(buffer.str());
+    EXPECT_EQ(0, p.errorCount());
+
+    std::string e1 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>a1</ci>\n\t\t\t\t<apply><plus/>\n\t\t\t\t\t<ci>b1</ci>\n\t\t\t\t\t<ci>c1</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math>";
+    std::string e2 = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>b2</ci>\n\t\t\t\t<apply><times/>\n\t\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\">2.0</cn>\n\t\t\t\t\t<ci>d</ci>\n\t\t\t\t</apply>\n\t\t\t</apply>\n\t\t</math>\n\t\t<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n\t\t\t<apply><eq/>\n\t\t\t\t<ci>d</ci>\n\t\t\t\t<cn xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\" cellml:units=\"dimensionless\" type=\"e-notation\">0.5<sep/>1</cn>\n\t\t\t</apply>\n\t\t</math>";
+
+    std::string a = model->getComponent("c1")->getMath();
+    EXPECT_EQ(e1, a);
+
+    a = model->getComponent("c2")->getMath();
+    EXPECT_EQ(e2, a);
+}
+

--- a/tests/resources/a_plus_b.cellml
+++ b/tests/resources/a_plus_b.cellml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model xmlns="http://www.cellml.org/cellml/2.0#" xmlns:cellml="http://www.cellml.org/cellml/2.0#"
+	name="andre_test_model" id="andreTestModelId">
+	<component name="c1" id="c1Id">
+		<variable units="dimensionless" name="a1" initial_value="1"
+			interface="public_and_private" />
+		<variable units="dimensionless" name="b1" interface="public_and_private" />
+		<variable units="dimensionless" name="c1" interface="public_and_private" />
+		<math xmlns="http://www.w3.org/1998/Math/MathML">
+			<apply><eq/>
+				<ci>a1</ci>
+				<apply><plus/>
+					<ci>b1</ci>
+					<ci>c1</ci>
+				</apply>
+			</apply>
+		</math>
+	</component>
+	<component name="c2" id="c2Id">
+		<variable units="dimensionless" name="a2" interface="public_and_private" />
+		<variable units="dimensionless" name="b2" interface="public_and_private" />
+		<variable units="dimensionless" name="c2" interface="public_and_private" />
+		<variable units="dimensionless" name="d" />
+		<math xmlns="http://www.w3.org/1998/Math/MathML">
+			<apply><eq/>
+				<ci>b2</ci>
+				<apply><times/>
+					<cn xmlns:cellml="http://www.cellml.org/cellml/2.0#" cellml:units="dimensionless">2.0</cn>
+					<ci>d</ci>
+				</apply>
+			</apply>
+		</math>
+		<math xmlns="http://www.w3.org/1998/Math/MathML">
+			<apply><eq/>
+				<ci>d</ci>
+				<cn xmlns:cellml="http://www.cellml.org/cellml/2.0#" cellml:units="dimensionless" type="e-notation">0.5<sep/>1</cn>
+			</apply>
+		</math>
+	</component>
+	<connection component_1="c1" component_2="c2">
+		<map_variables variable_1="a1" variable_2="a2"/>
+		<map_variables variable_1="b1" variable_2="b2"/>
+		<map_variables variable_1="c1" variable_2="c2"/>
+	</connection>
+</model>

--- a/tests/test_resources.cmake
+++ b/tests/test_resources.cmake
@@ -3,6 +3,7 @@ set(CELLML_SINE_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/sine_appro
 set(CELLML_SINE_IMPORTS_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/sine_approximations_import.xml")
 set(CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/complex_encapsulation.xml")
 set(CELLML_ORD_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/Ohara_Rudy_2011.cellml")
+set(CELLML_A_PLUS_B_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/a_plus_b.cellml")
 set(CELLML_INVALID_MODEL_RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/invalid_cellml_2.0.xml")
 
 set(TEST_RESOURCE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/test_resources.h)

--- a/tests/test_resources.h.in
+++ b/tests/test_resources.h.in
@@ -12,7 +12,8 @@ public:
         CELLML_SINE_MODEL_RESOURCE = 2,
         CELLML_SINE_IMPORTS_MODEL_RESOURCE = 3,
         CELLML_ORD_MODEL_RESOURCE = 4,
-        CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE = 5
+        CELLML_COMPLEX_ENCAPSULATION_MODEL_RESOURCE = 5,
+        CELLML_A_PLUS_B_MODEL_RESOURCE = 6
     };
 
     TestResources()
@@ -42,6 +43,10 @@ public:
         if (resourceName == TestResources::CELLML_ORD_MODEL_RESOURCE)
         {
             return "@CELLML_ORD_MODEL_RESOURCE@";
+        }
+        if (resourceName == TestResources::CELLML_A_PLUS_B_MODEL_RESOURCE)
+        {
+            return "@CELLML_A_PLUS_B_MODEL_RESOURCE@";
         }
         return 0;
     }


### PR DESCRIPTION
New test parses a model which contains a component with multiple math children,
which is expected to parse fine. Due to #183 this is not the case and one of the
math children is discarded.

