### PR TITLE
[bindings] Split Python tests into multiple functions. Closes #225.

### DIFF
--- a/tests/bindings/python/test_component.py
+++ b/tests/bindings/python/test_component.py
@@ -1,30 +1,34 @@
 #
 # Tests the Component class bindings
 #
-import sys
 import unittest
+
 
 class ComponentTestCase(unittest.TestCase):
 
-    def test_component(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Component
-        
+
         # Test create/copy/destroy
         x = Component()
         del(x)
         y = Component()
         z = Component(y)
         del(y, z)
-        
-        # Test inheritance
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import Component
+
         x = Component()
         self.assertIsInstance(x, libcellml.ComponentEntity)
         self.assertIsInstance(x, libcellml.ImportedEntity)
         self.assertIsInstance(x, libcellml.NamedEntity)
         self.assertIsInstance(x, libcellml.Entity)
-        
-        # Test access to inherited methods
+
+    def test_inherited_methods(self):
+        from libcellml import Component
+
         x = Component()
         idx = 'test'
         self.assertEqual(x.getId(), '')
@@ -32,44 +36,45 @@ class ComponentTestCase(unittest.TestCase):
         self.assertEqual(x.getId(), idx)
         y = Component(x)
         self.assertEqual(y.getId(), idx)
-        del(x, y, idx)
-        
-        # Test own methods
 
-        # void setSourceComponent(const ImportPtr& imp,
-        #   const std::string &name)
-        from libcellml import ImportSource
+    def test_set_source(self):
+        from libcellml import Component, ImportSource
+
         x = Component()
         i = ImportSource()
         i.setSource('bonjour')
         x.setSourceComponent(i, 'camembert')
         self.assertEqual(x.getImportSource().getSource(), 'bonjour')
         self.assertEqual(x.getImportReference(), 'camembert')
-        del(x, i)
+
+    def test_math(self):
+        from libcellml import Component
 
         # appendMath(const std::string &math)
         x = Component()
         x.appendMath('More maths')
         x.appendMath(' please!')
-        
+
         # std::string getMath()
         self.assertEqual(x.getMath(), 'More maths please!')
         x = Component()
         self.assertEqual(x.getMath(), '')
-        
+
         # void setMath(const std::string &math)
         x.setMath('bonjour')
         self.assertEqual(x.getMath(), 'bonjour')
         x.setMath('hola')
         self.assertEqual(x.getMath(), 'hola')
-        del(x)
 
-        # void addVariable(const VariablePtr &v)
-        from libcellml import Variable
+    def test_add_variable(self):
+        from libcellml import Component, Variable
+
         c = Component()
         v = Variable()
         c.addVariable(v)
-        del(c, v)
+
+    def test_has_variable(self):
+        from libcellml import Component, Variable
 
         # bool hasVariable(const VariablePtr &variable)
         c = Component()
@@ -79,7 +84,7 @@ class ComponentTestCase(unittest.TestCase):
         self.assertTrue(c.hasVariable(v))
         self.assertFalse(c.hasVariable(Variable()))
         del(c, v)
-        
+
         # bool hasVariable(const std::string &name)
         c = Component()
         self.assertFalse(c.hasVariable(''))
@@ -93,7 +98,10 @@ class ComponentTestCase(unittest.TestCase):
         c.addVariable(v2)
         self.assertTrue(c.hasVariable(name))
         del(c, v1, v2, name)
-        
+
+    def test_remove_variable(self):
+        from libcellml import Component, Variable
+
         # bool removeVariable(size_t index)
         c = Component()
         self.assertFalse(c.removeVariable(0))
@@ -105,7 +113,7 @@ class ComponentTestCase(unittest.TestCase):
         self.assertTrue(c.removeVariable(0))
         self.assertFalse(c.removeVariable(0))
         del(c)
-        
+
         # bool removeVariable(const std::string &name)
         c = Component()
         self.assertFalse(c.removeVariable(''))
@@ -120,7 +128,7 @@ class ComponentTestCase(unittest.TestCase):
         self.assertTrue(c.removeVariable(name))
         self.assertFalse(c.removeVariable(name))
         del(c, v1, name)
-        
+
         # bool removeVariable(const VariablePtr &variable)
         c = Component()
         v1 = Variable()
@@ -130,8 +138,10 @@ class ComponentTestCase(unittest.TestCase):
         self.assertFalse(c.removeVariable(v2))
         self.assertTrue(c.removeVariable(v1))
         self.assertFalse(c.removeVariable(v1))
-        del(c, v1, v2)
-        
+
+    def test_remove_all_variables(self):
+        from libcellml import Component, Variable
+
         # void removeAllVariables()
         c = Component()
         v1 = Variable()
@@ -139,12 +149,14 @@ class ComponentTestCase(unittest.TestCase):
         c.addVariable(v1)
         c.addVariable(v2)
         self.assertTrue(c.hasVariable(v1))
-        self.assertTrue(c.hasVariable(v2))        
+        self.assertTrue(c.hasVariable(v2))
         c.removeAllVariables()
         self.assertFalse(c.hasVariable(v1))
         self.assertFalse(c.hasVariable(v2))
-        del(c, v1, v2)
-                
+
+    def test_get_variable(self):
+        from libcellml import Component, Variable
+
         # VariablePtr getVariable(size_t index)
         c = Component()
         v = Variable()
@@ -159,7 +171,7 @@ class ComponentTestCase(unittest.TestCase):
         self.assertIsNotNone(c.getVariable(0))
         self.assertEqual(c.getVariable(0).getName(), name)
         del(c, v, name)
-                
+
         # VariablePtr getVariable(const std::string &name)
         c = Component()
         v = Variable()
@@ -170,8 +182,10 @@ class ComponentTestCase(unittest.TestCase):
         self.assertIsNone(c.getVariable('red'))
         self.assertIsNotNone(c.getVariable(name))
         self.assertEqual(c.getVariable(name).getName(), name)
-        del(c, v, name)
-        
+
+    def test_variable_count(self):
+        from libcellml import Component, Variable
+
         # size_t variableCount()
         c = Component()
         self.assertEqual(c.variableCount(), 0)
@@ -183,7 +197,7 @@ class ComponentTestCase(unittest.TestCase):
         self.assertEqual(c.variableCount(), 1)
         c.removeVariable('')
         self.assertEqual(c.variableCount(), 0)
-        del(c)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_component_entity.py
+++ b/tests/bindings/python/test_component_entity.py
@@ -1,21 +1,24 @@
 #
 # Tests the ComponentEntity class bindings
 #
-import sys
 import unittest
+
 
 class ComponentEntityTestCase(unittest.TestCase):
 
-    def test_component_entity(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import ComponentEntity
-        
+
         # Test create/copy/destroy
         x = ComponentEntity()
         del(x)
         y = ComponentEntity()
         z = ComponentEntity(y)
         del(y, z)
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import ComponentEntity
 
         # Test inheritance
         x = ComponentEntity()
@@ -30,17 +33,18 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertEqual(x.getId(), idx)
         y = ComponentEntity(x)
         self.assertEqual(y.getId(), idx)
-        del(x, y, idx)
-        
-        # Test own methods
+
+    def test_add_component(self):
+        from libcellml import ComponentEntity, Component
 
         # void addComponent(const ComponentPtr &c)
-        from libcellml import Component
         x = ComponentEntity()
         y = Component()
         x.addComponent(y)
-        del(x, y)
-        
+
+    def test_remove_component(self):
+        from libcellml import ComponentEntity, Component
+
         # bool removeComponent(size_t index)
         x = ComponentEntity()
         self.assertFalse(x.removeComponent(0))
@@ -49,10 +53,10 @@ class ComponentEntityTestCase(unittest.TestCase):
         y = Component()
         x.addComponent(y)
         self.assertFalse(x.removeComponent(1))
-        self.assertFalse(x.removeComponent(-1))        
+        self.assertFalse(x.removeComponent(-1))
         self.assertTrue(x.removeComponent(0))
         del(x, y)
-        
+
         # bool removeComponent(const std::string &name,
         #    bool searchEncapsulated=true)
         x = ComponentEntity()
@@ -85,7 +89,7 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertTrue(x.removeComponent(name, True))
         self.assertFalse(x.removeComponent(name, True))
         del(x, y, z, name)
-        
+
         # bool removeComponent(const ComponentPtr &component,
         #   bool searchEncapsulated=true)
         x = ComponentEntity()
@@ -109,7 +113,10 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertTrue(x.removeComponent(z, True))
         self.assertFalse(x.removeComponent(z, True))
         del(x, y, z)
-        
+
+    def test_remove_all_components(self):
+        from libcellml import ComponentEntity, Component
+
         # void removeAllComponents()
         x = ComponentEntity()
         x.removeAllComponents()
@@ -117,8 +124,10 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertEqual(x.componentCount(), 1)
         x.removeAllComponents()
         self.assertEqual(x.componentCount(), 0)
-        del(x)
-        
+
+    def test_contains_component(self):
+        from libcellml import ComponentEntity, Component
+
         # bool containsComponent(const std::string &name,
         #   bool searchEncapsulated)
         x = ComponentEntity()
@@ -140,7 +149,7 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertTrue(x.containsComponent(name2, True))
         self.assertTrue(x.containsComponent(name2, name2))
         del(x, y, z, name, name2)
-        
+
         # bool containsComponent(const ComponentPtr &component,
         #   bool searchEncapsulated)
         x = ComponentEntity()
@@ -158,12 +167,15 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertTrue(x.containsComponent(z, True))
         self.assertTrue(x.containsComponent(z, z))
         del(x, y, z)
-        
+
+    def test_get_component(self):
+        from libcellml import ComponentEntity, Component
+
         # ComponentPtr getComponent(size_t index)
         name = 'testo'
         x = ComponentEntity()
         y = Component()
-        y.setName(name)        
+        y.setName(name)
         self.assertIsNone(x.getComponent(0))
         self.assertIsNone(x.getComponent(1))
         self.assertIsNone(x.getComponent(-1))
@@ -172,13 +184,13 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertIsNone(x.getComponent(-1))
         self.assertIsNotNone(x.getComponent(0), y)
         self.assertEqual(x.getComponent(0).getName(), name)
-        
+
         # ComponentPtr getComponent(const std::string &name,
         #   bool searchEncapsulated=true)
         name = 'testo'
         x = ComponentEntity()
         y = Component()
-        y.setName(name)        
+        y.setName(name)
         self.assertIsNone(x.getComponent('bonjour'))
         self.assertIsNone(x.getComponent(name))
         self.assertIsNone(x.getComponent(name, True))
@@ -205,12 +217,15 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertIsNotNone(x.getComponent(name, 1))
         self.assertIsNotNone(x.getComponent(name, name))
         del(x, y, z, name)
-        
+
+    def test_take_component(self):
+        from libcellml import ComponentEntity, Component
+
         # ComponentPtr takeComponent(size_t index)
         name = 'testo'
         x = ComponentEntity()
         y = Component()
-        y.setName(name)        
+        y.setName(name)
         self.assertIsNone(x.takeComponent(0))
         self.assertIsNone(x.takeComponent(1))
         self.assertIsNone(x.takeComponent(-1))
@@ -222,13 +237,13 @@ class ComponentEntityTestCase(unittest.TestCase):
         x.addComponent(y)
         self.assertEqual(x.takeComponent(0).getName(), name)
         self.assertIsNone(x.takeComponent(0), y)
-        
+
         # ComponentPtr takeComponent(const std::string &name,
         #   bool searchEncapsulated=true)
         name = 'testo'
         x = ComponentEntity()
         y = Component()
-        y.setName(name)        
+        y.setName(name)
         self.assertIsNone(x.takeComponent('bonjour'))
         self.assertIsNone(x.takeComponent(name))
         self.assertIsNone(x.takeComponent(name, True))
@@ -270,7 +285,7 @@ class ComponentEntityTestCase(unittest.TestCase):
         y = Component()
         y.addComponent(z)
         x = ComponentEntity()
-        x.addComponent(y)        
+        x.addComponent(y)
         self.assertIsNotNone(x.takeComponent(name, 1))
         self.assertIsNone(x.takeComponent(name, 1))
         del(x, y, name)
@@ -284,7 +299,10 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertIsNotNone(x.takeComponent(name, name))
         self.assertIsNone(x.takeComponent(name, name))
         del(x, y, z, name)
-        
+
+    def test_replace_component(self):
+        from libcellml import ComponentEntity, Component
+
         # bool replaceComponent(size_t index, const ComponentPtr &c)
         x = ComponentEntity()
         a = Component()
@@ -300,7 +318,7 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertTrue(x.replaceComponent(0, b))
         self.assertTrue(x.containsComponent(b))
         self.assertFalse(x.containsComponent(a))
-        
+
         # bool replaceComponent(const std::string &name, const ComponentPtr &c,
         #   bool searchEncapsulated = true)
         x = ComponentEntity()
@@ -324,7 +342,7 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertTrue(x.replaceComponent('b', a, 'yes'))
         self.assertTrue(x.replaceComponent('a', b, a))
         del(x, a, b)
-        
+
         # replaceComponent(const ComponentPtr &c1, const ComponentPtr &c2,
         #   bool searchEncapsulated = true)
         x = ComponentEntity()
@@ -345,7 +363,10 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertTrue(x.replaceComponent(a, b, []))
         self.assertTrue(x.replaceComponent(b, a, 'yes'))
         self.assertTrue(x.replaceComponent(a, b, a))
-        
+
+    def test_component_count(self):
+        from libcellml import ComponentEntity, Component
+
         # size_t componentCount()
         x = ComponentEntity()
         self.assertEqual(x.componentCount(), 0)
@@ -366,6 +387,7 @@ class ComponentEntityTestCase(unittest.TestCase):
         self.assertEqual(x.componentCount(), 1)
         self.assertTrue(x.removeComponent(0))
         self.assertEqual(x.componentCount(), 0)
-        
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_entity.py
+++ b/tests/bindings/python/test_entity.py
@@ -1,62 +1,69 @@
 #
 # Tests the entity class bindings
 #
-import sys
 import unittest
+
 
 class EntityTestCase(unittest.TestCase):
 
-    def test_entity(self):
+    def test_create_destroy(self):
         from libcellml import Entity
-        
-        # Test create/copy/destroy
+
         x = Entity()
         del(x)
         y = Entity()
         z = Entity(y)
         del(y, z)
-        
-        # Test own methods
+
+    def test_id(self):
+        from libcellml import Entity
 
         # std::string getId()
         x = Entity()
         self.assertEqual(x.getId(), '')
 
-        # void setId(const std::string &id)        
+        # void setId(const std::string &id)
         idx = 'test'
         x.setId(idx)
         self.assertEqual(x.getId(), idx)
-        
-        # copy constructor
+
+    def test_copy_constructor(self):
+        from libcellml import Entity
+
+        x = Entity()
+        idx = 'hello'
+        x.setId(idx)
         y = Entity(x)
         self.assertEqual(y.getId(), idx)
-        del(x, y, idx)
-        
+
+    def test_get_parent(self):
+        from libcellml import Entity
+
         # void* getParent
-        #TODO: This method might be moved out of entity!
-        #TODO: If not, this needs a workaround!
+        # TODO: This method might be moved out of entity!
+        # TODO: If not, this needs a workaround!
         x = Entity()
         self.assertIsNone(x.getParent())
-        del(x)
-        
+
+    def test_set_parent(self):
+        from libcellml import Entity, Model, Component
+
         # void setParent(Model *parent)
-        from libcellml import Model
         m = Model()
         x = Entity()
         x.setParent(m)
         self.assertIsNotNone(x.getParent())
-        #TODO: Check equivalence
-        del(x, m)
-        
-        # void setParent(Component *parent)
-        from libcellml import Component
+        # TODO: Check equivalence
+
         c = Component()
         x = Entity()
         x.setParent(c)
         self.assertIsNotNone(x.getParent())
-        #TODO: Check equivalence
-        del(x, c)
-        
+        # TODO: Check equivalence
+
+    def test_clear_parent(self):
+        from libcellml import Entity, Model, Component
+
         # void clearParent()
         x = Entity()
         self.assertIsNone(x.getParent())
@@ -68,7 +75,9 @@ class EntityTestCase(unittest.TestCase):
         self.assertIsNotNone(x.getParent())
         x.clearParent()
         self.assertIsNone(x.getParent())
-        del(x)
+
+    def test_has_parent(self):
+        from libcellml import Entity, Component
 
         # bool hasParent(Component* c)
         x = Entity()
@@ -83,6 +92,7 @@ class EntityTestCase(unittest.TestCase):
         x.setParent(d)
         self.assertTrue(x.hasParent(d))
         self.assertTrue(x.hasParent(c))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_error.py
+++ b/tests/bindings/python/test_error.py
@@ -1,23 +1,23 @@
 #
 # Tests the Error class bindings
 #
-import sys
 import unittest
+
 
 class ErrorTestCase(unittest.TestCase):
 
-    def test_error(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Error
-        
-        # Test create/copy/destroy
+
         x = Error()
         del(x)
         y = Error()
         z = Error(y)
         del(y, z)
-        
-        # Test Kind enum
+
+    def test_kind_enum(self):
+        from libcellml import Error
+
         self.assertIsInstance(Error.Kind.COMPONENT, int)
         self.assertIsInstance(Error.Kind.CONNECTION, int)
         self.assertIsInstance(Error.Kind.ENCAPSULATION, int)
@@ -28,15 +28,16 @@ class ErrorTestCase(unittest.TestCase):
         self.assertIsInstance(Error.Kind.UNITS, int)
         self.assertIsInstance(Error.Kind.VARIABLE, int)
         self.assertIsInstance(Error.Kind.XML, int)
+
         # Test conversion to enum
         e = Error()
         e.setKind(Error.Kind.COMPONENT)
         self.assertRaises(RuntimeError, e.setKind, Error.Kind.COMPONENT - 1)
         self.assertRaises(RuntimeError, e.setKind, Error.Kind.XML + 1)
-        del(e)
-        
-        # Test SpecificationRule enum
-        from libcellml import SpecificationRule
+
+    def test_specification_rule_enum(self):
+        from libcellml import Error, SpecificationRule
+
         self.assertIsInstance(SpecificationRule.UNDEFINED, int)
         self.assertIsInstance(SpecificationRule.MODEL_ELEMENT, int)
         self.assertIsInstance(SpecificationRule.MODEL_NAME, int)
@@ -68,8 +69,8 @@ class ErrorTestCase(unittest.TestCase):
         self.assertIsInstance(SpecificationRule.VARIABLE_UNITS, int)
         self.assertIsInstance(SpecificationRule.VARIABLE_INTERFACE, int)
         self.assertIsInstance(SpecificationRule.VARIABLE_INITIAL_VALUE, int)
-        self.assertIsInstance(SpecificationRule.ENCAPSULATION_COMPONENT_REF,
-            int)
+        self.assertIsInstance(
+            SpecificationRule.ENCAPSULATION_COMPONENT_REF, int)
         self.assertIsInstance(SpecificationRule.COMPONENT_REF_COMPONENT, int)
         self.assertIsInstance(SpecificationRule.COMPONENT_REF_CHILD, int)
         self.assertIsInstance(
@@ -81,22 +82,27 @@ class ErrorTestCase(unittest.TestCase):
         self.assertIsInstance(SpecificationRule.MAP_COMPONENTS_COMPONENT2, int)
         self.assertIsInstance(SpecificationRule.MAP_VARIABLES_VARIABLE1, int)
         self.assertIsInstance(SpecificationRule.MAP_VARIABLES_VARIABLE2, int)
+
         # Test conversion to enum
         e = Error()
         e.setRule(SpecificationRule.UNDEFINED)
-        self.assertRaises(RuntimeError, e.setRule, 
-            SpecificationRule.UNDEFINED - 1)
-        self.assertRaises(RuntimeError, e.setRule,
+        self.assertRaises(
+            RuntimeError, e.setRule, SpecificationRule.UNDEFINED - 1)
+        self.assertRaises(
+            RuntimeError, e.setRule,
             SpecificationRule.MAP_VARIABLES_VARIABLE2 + 1)
         del(e)
-        
-        # Test methods
-        
+
+    def test_set_description(self):
+        from libcellml import Error
+
         # void setDescription(const std::string& description)
         e = Error()
         e.setDescription('hello')
         e.setDescription('')
-        del(e)
+
+    def test_get_description(self):
+        from libcellml import Error
 
         # std::string getDescription()
         d = 'hi'
@@ -106,44 +112,60 @@ class ErrorTestCase(unittest.TestCase):
         self.assertEqual(e.getDescription(), d)
         del(d, e)
 
+    def test_set_kind(self):
+        from libcellml import Error
+
         # void setKind(Kind kind)
         e = Error()
         e.setKind(Error.Kind.CONNECTION)
-        del(e)
+
+    def test_get_kind(self):
+        from libcellml import Error
 
         # Kind getKind()
         e = Error()
         self.assertEqual(e.getKind(), Error.Kind.UNDEFINED)
         e.setKind(Error.Kind.MATHML)
         self.assertEqual(e.getKind(), Error.Kind.MATHML)
-        del(e)
+
+    def test_is_kind(self):
+        from libcellml import Error
 
         # bool isKind(const Kind &kind)
         e = Error()
         self.assertTrue(e.isKind(Error.Kind.UNDEFINED))
         self.assertFalse(e.isKind(Error.Kind.MODEL))
-        del(e)
+
+    def test_set_rule(self):
+        from libcellml import Error, SpecificationRule
 
         # void setRule(SpecificationRule rule)
         e = Error()
         e.setRule(SpecificationRule.MAP_VARIABLES_VARIABLE2)
-        del(e)
+
+    def test_get_rule(self):
+        from libcellml import Error, SpecificationRule
 
         # SpecificationRule getRule()
         e = Error()
         self.assertEqual(e.getRule(), SpecificationRule.UNDEFINED)
-        del(e)
+
+    def test_get_specification_heading(self):
+        from libcellml import Error
 
         # std::string getSpecificationHeading()
         e = Error()
         self.assertEqual('', e.getSpecificationHeading())
-        del(e)
+
+    def test_set_component(self):
+        from libcellml import Error, Component
 
         # void setComponent(const ComponentPtr &component)
-        from libcellml import Component
         e = Error()
         e.setComponent(Component())
-        del(e)
+
+    def test_get_component(self):
+        from libcellml import Error, Component
 
         # ComponentPtr getComponent()
         e = Error()
@@ -154,13 +176,16 @@ class ErrorTestCase(unittest.TestCase):
         e.setComponent(c)
         self.assertIsInstance(e.getComponent(), Component)
         self.assertEqual(e.getComponent().getName(), name)
-        del(e, c, name)
+
+    def test_set_import_source(self):
+        from libcellml import Error, ImportSource
 
         # void setImportSource(const ImportSourcePtr &import)
-        from libcellml import ImportSource
         e = Error()
         e.setImportSource(ImportSource())
-        del(e)
+
+    def test_get_import_source(self):
+        from libcellml import Error, ImportSource
 
         # ImportSourcePtr getImportSource()
         e = Error()
@@ -171,13 +196,16 @@ class ErrorTestCase(unittest.TestCase):
         e.setImportSource(i)
         self.assertIsInstance(e.getImportSource(), ImportSource)
         self.assertEqual(e.getImportSource().getId(), name)
-        del(e, i, name)
+
+    def test_set_model(self):
+        from libcellml import Error, Model
 
         # void setModel(const ModelPtr &model)
-        from libcellml import Model
         e = Error()
         e.setModel(Model())
-        del(e)
+
+    def test_get_model(self):
+        from libcellml import Error, Model
 
         # ModelPtr getModel()
         e = Error()
@@ -188,14 +216,17 @@ class ErrorTestCase(unittest.TestCase):
         e.setModel(m)
         self.assertIsInstance(e.getModel(), Model)
         self.assertEqual(e.getModel().getName(), name)
-        del(e, m, name)
-        
+
+    def test_set_units(self):
+        from libcellml import Error, Units
+
         # void setUnits(const UnitsPtr &units)
-        from libcellml import Units
         e = Error()
         e.setUnits(Units())
-        del(e)
-        
+
+    def test_get_units(self):
+        from libcellml import Error, Units
+
         # UnitsPtr getUnits()
         e = Error()
         self.assertIsNone(e.getUnits())
@@ -205,13 +236,16 @@ class ErrorTestCase(unittest.TestCase):
         e.setUnits(u)
         self.assertIsInstance(e.getUnits(), Units)
         self.assertEqual(e.getUnits().getName(), name)
-        del(e, u, name)
+
+    def test_set_variable(self):
+        from libcellml import Error, Variable
 
         # void setVariable(const VariablePtr &variable)
-        from libcellml import Variable
         e = Error()
         e.setVariable(Variable())
-        del(e)
+
+    def test_get_variable(self):
+        from libcellml import Error, Variable
 
         # VariablePtr getVariable()
         e = Error()
@@ -222,7 +256,7 @@ class ErrorTestCase(unittest.TestCase):
         e.setVariable(v)
         self.assertIsInstance(e.getVariable(), Variable)
         self.assertEqual(e.getVariable().getName(), name)
-        del(e, v, name)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_import_source.py
+++ b/tests/bindings/python/test_import_source.py
@@ -1,43 +1,48 @@
 #
 # Tests the ImportSource class bindings.
 #
-import sys
 import unittest
+
 
 class ImportSourceTestCase(unittest.TestCase):
 
     def test_import_source(self):
-        import libcellml
         from libcellml import ImportSource
 
         # Test create/copy/destroy
         x = ImportSource()
-        del(x)
         y = ImportSource()
         z = ImportSource(y)
-        del(y, z)
-        
-        # Test inheritance
+        del(x, y, z)
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import ImportSource
+
         x = ImportSource()
         self.assertIsInstance(x, libcellml.Entity)
 
-        # Test own methods
-        
+    def test_set_source(self):
+        from libcellml import ImportSource
+
         # void setSource(const std::string &reference)
         x = ImportSource()
         x.setSource('')
         x.setSource('hello')
         x.setSource('')
-        del(x)
-        
+
+    def test_get_source(self):
+        from libcellml import ImportSource
+
         # std::string getSource()
         source = 'cheers'
         x = ImportSource()
         self.assertEqual(x.getSource(), '')
         x.setSource(source)
         self.assertEqual(x.getSource(), source)
-        x.setSource('')        
+        x.setSource('')
         self.assertEqual(x.getSource(), '')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_imported_entity.py
+++ b/tests/bindings/python/test_imported_entity.py
@@ -2,23 +2,23 @@
 # Tests the bindings for ImportedEntity, which is the base class for all
 # entities that can be imported.
 #
-import sys
 import unittest
+
 
 class ImportedEntityTestCase(unittest.TestCase):
 
-    def test_imported_entity(self):
+    def test_create_destroy(self):
+        from libcellml import ImportedEntity
+
+        x = ImportedEntity()
+        y = ImportedEntity()
+        z = ImportedEntity(y)
+        del(x, y, z)
+
+    def test_inheritance(self):
         import libcellml
         from libcellml import ImportedEntity
 
-        # Test create/copy/destroy
-        x = ImportedEntity()
-        del(x)
-        y = ImportedEntity()
-        z = ImportedEntity(y)
-        del(y, z)
-
-        # Test inheritance
         x = ImportedEntity()
         self.assertIsInstance(x, libcellml.NamedEntity)
         self.assertIsInstance(x, libcellml.Entity)
@@ -29,16 +29,17 @@ class ImportedEntityTestCase(unittest.TestCase):
         self.assertEqual(x.getId(), '')
         x.setId(idx)
         self.assertEqual(x.getId(), idx)
-        del(x, idx)
 
-        # Test own methods
+    def test_set_import_source(self):
+        from libcellml import ImportedEntity, ImportSource
 
         # void setImportSource(const ImportPtr &imp)
-        from libcellml import ImportSource
         x = ImportedEntity()
         x.setImportSource(ImportSource())
         x.setImportSource(None)
-        del(x)
+
+    def test_is_import(self):
+        from libcellml import ImportedEntity, ImportSource
 
         # bool isImport()
         x = ImportedEntity()
@@ -47,7 +48,9 @@ class ImportedEntityTestCase(unittest.TestCase):
         self.assertTrue(x.isImport())
         x.setImportSource(None)
         self.assertFalse(x.isImport())
-        del(x)
+
+    def test_get_import_source(self):
+        from libcellml import ImportedEntity, ImportSource
 
         # ImportSourcePtr getImportSource()
         i = ImportSource()
@@ -58,7 +61,9 @@ class ImportedEntityTestCase(unittest.TestCase):
         x.setImportSource(i)
         self.assertIsNotNone(x.getImportSource())
         self.assertEqual(x.getImportSource().getSource(), source)
-        del(x, i, source)
+
+    def test_set_import_reference(self):
+        from libcellml import ImportedEntity
 
         # void setImportReference(const std::string &reference)
         r = 'yes'
@@ -66,7 +71,9 @@ class ImportedEntityTestCase(unittest.TestCase):
         x.setImportReference('')
         x.setImportReference(r)
         x.setImportReference('')
-        del(r, x)
+
+    def test_get_import_reference(self):
+        from libcellml import ImportedEntity
 
         # std::string getImportReference()
         r = 'yes'
@@ -76,7 +83,7 @@ class ImportedEntityTestCase(unittest.TestCase):
         self.assertEqual(x.getImportReference(), r)
         x.setImportReference('')
         self.assertEqual(x.getImportReference(), '')
-        del(r, x)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_logger.py
+++ b/tests/bindings/python/test_logger.py
@@ -1,29 +1,30 @@
 #
 # Tests the Error class bindings
 #
-import sys
 import unittest
+
 
 class LoggerTestCase(unittest.TestCase):
 
-    def test_logger(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Logger
-        
+
         # Test create/copy/destroy
         x = Logger()
         del(x)
         y = Logger()
         z = Logger(y)
         del(y, z)
-        
-        # Test methods
-        
+
+    def test_add_error(self):
+        from libcellml import Logger, Error
+
         # void addError(const ErrorPtr error)
-        from libcellml import Error
         x = Logger()
         x.addError(Error())
-        del(x)
+
+    def test_error_count(self):
+        from libcellml import Logger, Error
 
         # size_t errorCount()
         x = Logger()
@@ -32,8 +33,10 @@ class LoggerTestCase(unittest.TestCase):
         self.assertEqual(x.errorCount(), 1)
         x.addError(Error())
         self.assertEqual(x.errorCount(), 2)
-        del(x)
-        
+
+    def test_get_error(self):
+        from libcellml import Logger, Error
+
         # ErrorPtr getError(size_t index)
         x = Logger()
         self.assertIsNone(x.getError(0))
@@ -45,8 +48,10 @@ class LoggerTestCase(unittest.TestCase):
         self.assertIsNotNone(x.getError(0))
         self.assertIsNone(x.getError(1))
         self.assertEqual(x.getError(0).getKind(), Error.Kind.MODEL)
-        del(x, e)
-        
+
+    def test_clear_errors(self):
+        from libcellml import Logger, Error
+
         # void clearErrors()
         x = Logger()
         self.assertEqual(x.errorCount(), 0)
@@ -55,7 +60,7 @@ class LoggerTestCase(unittest.TestCase):
         self.assertEqual(x.errorCount(), 2)
         x.clearErrors()
         self.assertEqual(x.errorCount(), 0)
-        del(x)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_model.py
+++ b/tests/bindings/python/test_model.py
@@ -1,29 +1,30 @@
 #
 # Tests the Model class bindings
 #
-import sys
 import unittest
+
 
 class ModelTestCase(unittest.TestCase):
 
-    def test_model(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Model
-        
-        # Test create/copy/destroy
+
         x = Model()
         del(x)
         y = Model()
         z = Model(y)
         del(y, z)
-        
-        # Test inheritance
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import Model
+
         x = Model()
         self.assertIsInstance(x, libcellml.ComponentEntity)
         self.assertIsInstance(x, libcellml.ImportedEntity)
         self.assertIsInstance(x, libcellml.NamedEntity)
         self.assertIsInstance(x, libcellml.Entity)
-        
+
         # Test access to inherited methods
         x = Model()
         idx = 'test'
@@ -32,17 +33,18 @@ class ModelTestCase(unittest.TestCase):
         self.assertEqual(x.getId(), idx)
         y = Model(x)
         self.assertEqual(y.getId(), idx)
-        del(x, y, idx)
-        
-        # Test own methods
-        
+
+    def test_add_units(self):
+        from libcellml import Model, Units
+
         # void addUnits(const UnitsPtr &units)
-        from libcellml import Units
         m = Model()
         u = Units()
         m.addUnits(u)
-        del(m, u)
-        
+
+    def test_remove_units(self):
+        from libcellml import Model, Units
+
         # bool removeUnits(size_t index)
         m = Model()
         u = Units()
@@ -53,9 +55,9 @@ class ModelTestCase(unittest.TestCase):
         self.assertFalse(m.removeUnits(1))
         self.assertFalse(m.removeUnits(-1))
         self.assertTrue(m.removeUnits(0))
-        self.assertFalse(m.removeUnits(0))        
+        self.assertFalse(m.removeUnits(0))
         del(m, u)
-        
+
         # bool removeUnits(const std::string &name)
         name = 'bert'
         m = Model()
@@ -66,7 +68,7 @@ class ModelTestCase(unittest.TestCase):
         self.assertFalse(m.removeUnits('ernie'))
         self.assertTrue(m.removeUnits(name))
         del(m, u, name)
-        
+
         # bool removeUnits(const UnitsPtr &units)
         m = Model()
         u1 = Units()
@@ -77,7 +79,10 @@ class ModelTestCase(unittest.TestCase):
         self.assertTrue(m.removeUnits(u1))
         self.assertFalse(m.removeUnits(u1))
         del(m, u1, u2)
-        
+
+    def test_remove_all_units(self):
+        from libcellml import Model, Units
+
         # void removeAllUnits()
         m = Model()
         u1 = Units()
@@ -88,7 +93,10 @@ class ModelTestCase(unittest.TestCase):
         self.assertFalse(m.removeUnits(u1))
         self.assertFalse(m.removeUnits(u2))
         del(m, u1, u2)
-        
+
+    def test_has_units(self):
+        from libcellml import Model, Units
+
         # bool hasUnits(const std::string &name)
         name = 'loud'
         m = Model()
@@ -97,8 +105,10 @@ class ModelTestCase(unittest.TestCase):
         m.addUnits(u)
         self.assertFalse(m.hasUnits('hi'))
         self.assertTrue(m.hasUnits(name))
-        del(name, m, u)
-        
+
+    def test_get_units(self):
+        from libcellml import Model, Units
+
         # UnitsPtr getUnits(size_t index)
         name = 'naaame'
         m = Model()
@@ -113,7 +123,7 @@ class ModelTestCase(unittest.TestCase):
         self.assertIsNotNone(m.getUnits(0))
         self.assertEqual(m.getUnits(0).getName(), name)
         del(m, u, name)
-        
+
         # UnitsPtr getUnits(const std::string &name)
         name = 'kermit'
         m = Model()
@@ -124,7 +134,10 @@ class ModelTestCase(unittest.TestCase):
         self.assertIsNotNone(m.getUnits(name))
         self.assertEqual(m.getUnits(name).getName(), name)
         del(m, u, name)
-        
+
+    def test_take_units(self):
+        from libcellml import Model, Units
+
         # UnitsPtr takeUnits(size_t index)
         name = 'piggy'
         m = Model()
@@ -142,7 +155,7 @@ class ModelTestCase(unittest.TestCase):
         m.addUnits(u)
         self.assertEqual(m.takeUnits(1).getName(), name)
         del(m, u)
-        
+
         # UnitsPtr takeUnits(const std::string &name)
         name = 'aloha'
         m = Model()
@@ -153,7 +166,10 @@ class ModelTestCase(unittest.TestCase):
         self.assertEquals(m.takeUnits(name).getName(), name)
         self.assertIsNone(m.takeUnits(name))
         del(m, u, name)
-        
+
+    def test_replace_units(self):
+        from libcellml import Model, Units
+
         # bool replaceUnits(size_t index, const UnitsPtr &units)
         m = Model()
         u1 = Units()
@@ -166,7 +182,7 @@ class ModelTestCase(unittest.TestCase):
         self.assertFalse(m.replaceUnits(-1, u1))
         self.assertEqual(m.getUnits(0).getName(), 'b')
         del(m, u1, u2)
-        
+
         # bool replaceUnits(const std::string &name, const UnitsPtr &units)
         m = Model()
         a = Units()
@@ -179,7 +195,7 @@ class ModelTestCase(unittest.TestCase):
         self.assertTrue(m.replaceUnits('b', a))
         self.assertFalse(m.replaceUnits('b', a))
         del(m, a, b)
-        
+
         # bool replaceUnits(const UnitsPtr &oldUnits, const UnitsPtr &newUnits)
         m = Model()
         a = Units()
@@ -190,7 +206,10 @@ class ModelTestCase(unittest.TestCase):
         self.assertTrue(m.replaceUnits(b, a))
         self.assertFalse(m.replaceUnits(b, a))
         del(m, a, b)
-        
+
+    def test_units_count(self):
+        from libcellml import Model, Units
+
         # size_t unitsCount()
         m = Model()
         self.assertEqual(m.unitsCount(), 0)
@@ -201,6 +220,7 @@ class ModelTestCase(unittest.TestCase):
         m.removeAllUnits()
         self.assertEqual(m.unitsCount(), 0)
         del(m)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_named_entity.py
+++ b/tests/bindings/python/test_named_entity.py
@@ -1,15 +1,14 @@
 #
 # Tests the NamedEntity class bindings
 #
-import sys
 import unittest
+
 
 class NamedEntityTestCase(unittest.TestCase):
 
-    def test_named_entity(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import NamedEntity
-        
+
         # Test create/copy/destroy
         x = NamedEntity()
         del(x)
@@ -17,7 +16,10 @@ class NamedEntityTestCase(unittest.TestCase):
         z = NamedEntity(y)
         del(y, z)
 
-        # Test inheritance
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import NamedEntity
+
         x = NamedEntity()
         self.assertIsInstance(x, libcellml.Entity)
 
@@ -27,17 +29,19 @@ class NamedEntityTestCase(unittest.TestCase):
         self.assertEqual(x.getId(), '')
         x.setId(idx)
         self.assertEqual(x.getId(), idx)
-        del(x, idx)
-        
-        # Test own methods
-        
+
+    def test_set_name(self):
+        from libcellml import NamedEntity
+
         # void setName(const std::string &name)
         name = 'testo'
         x = NamedEntity()
         x.setName(name)
         x.setName('')
-        del(x, name)
-        
+
+    def test_get_name(self):
+        from libcellml import NamedEntity
+
         # std::string getName()
         name = 'testo'
         x = NamedEntity()
@@ -46,7 +50,7 @@ class NamedEntityTestCase(unittest.TestCase):
         self.assertEqual(x.getName(), name)
         x.setName('')
         self.assertEqual(x.getName(), '')
-        del(x, name)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_parser.py
+++ b/tests/bindings/python/test_parser.py
@@ -1,41 +1,42 @@
 #
 # Tests the Parser class bindings
 #
-import sys
 import unittest
+
 
 class ParserTestCase(unittest.TestCase):
 
-    def test_parser(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Parser
-        
-        # Test create/copy/destroy
+
         x = Parser()
         del(x)
         y = Parser()
         z = Parser(y)
         del(y, z)
-        
-        # Test inheritance
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import Parser
+
         x = Parser()
         self.assertIsInstance(x, libcellml.Logger)
 
         # Test access to inherited methods
-        idx = 'test'
         self.assertIsNone(x.getError(0))
         self.assertIsNone(x.getError(-1))
         self.assertEqual(x.errorCount(), 0)
         x.addError(libcellml.Error())
         self.assertEqual(x.errorCount(), 1)
-        del(x, idx)
-        
-        # Test own methods
-        
+
+    def test_parse_model(self):
+        import libcellml
+        from libcellml import Parser
+
         # ModelPtr parseModel(const std::string &input)
         p = Parser()
         self.assertIsInstance(p.parseModel('rubbish'), libcellml.Model)
-        del(p)
-        
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_printer.py
+++ b/tests/bindings/python/test_printer.py
@@ -1,41 +1,40 @@
 #
 # Tests the Printer class bindings
 #
-import sys
 import unittest
+
 
 class PrinterTestCase(unittest.TestCase):
 
-    def test_printer(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Printer
-        
-        # Test create/copy/destroy
+
         x = Printer()
         del(x)
         y = Printer()
         z = Printer(y)
         del(y, z)
-        
-        # Test inheritance
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import Printer
+
         x = Printer()
         self.assertIsInstance(x, libcellml.Logger)
 
         # Test access to inherited methods
-        idx = 'test'
         self.assertIsNone(x.getError(0))
         self.assertIsNone(x.getError(-1))
         self.assertEqual(x.errorCount(), 0)
         x.addError(libcellml.Error())
         self.assertEqual(x.errorCount(), 1)
-        del(x, idx)
-        
-        # Test own methods
-        
+
+    def test_print_model(self):
+        from libcellml import Printer, Model
+
         # std::string printModel(ModelPtr model)
         p = Printer()
-        self.assertIsInstance(p.printModel(libcellml.Model()), str)
-        del(p)
+        self.assertIsInstance(p.printModel(Model()), str)
 
         # std::string printModel(Model model)
         # This method shadows printModel(ModelPtr) so wasn't added
@@ -43,29 +42,36 @@ class PrinterTestCase(unittest.TestCase):
         # std::string printModel(Model *model)
         # This method shadows printModel(ModelPtr) so wasn't added
 
+    def test_print_units(self):
+        from libcellml import Printer, Units
+
         # std::string printUnits(UnitsPtr units)
         p = Printer()
-        self.assertIsInstance(p.printUnits(libcellml.Units()), str)
-        del(p)
+        self.assertIsInstance(p.printUnits(Units()), str)
 
         # std::string printUnits(Units units)
         # This method shadows printUnits(UnitsPtr) so wasn't added
 
+    def test_print_variable(self):
+        from libcellml import Printer, Variable
+
         # std::string printVariable(VariablePtr variable)\
         p = Printer()
-        self.assertIsInstance(p.printVariable(libcellml.Variable()), str)
-        del(p)
+        self.assertIsInstance(p.printVariable(Variable()), str)
 
         # This method shadows printVariable(VariablePtr) so wasn't added
         # std::string printVariable(Variable variable)
 
+    def test_print_component(self):
+        from libcellml import Printer, Component
+
         # std::string printComponent(ComponentPtr component)
         p = Printer()
-        self.assertIsInstance(p.printComponent(libcellml.Component()), str)
-        del(p)
+        self.assertIsInstance(p.printComponent(Component()), str)
 
         # This method shadows printComponent(ComponentPtr) so wasn't added
         # std::string printComponent(Component component)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_units.py
+++ b/tests/bindings/python/test_units.py
@@ -1,28 +1,29 @@
 #
 # Tests the Units class bindings
 #
-import sys
 import unittest
+
 
 class UnitsTestCase(unittest.TestCase):
 
-    def test_model(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Units
-        
-        # Test create/copy/destroy
+
         x = Units()
         del(x)
         y = Units()
         z = Units(y)
         del(y, z)
-        
-        # Test inheritance
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import Units
+
         x = Units()
         self.assertIsInstance(x, libcellml.ImportedEntity)
         self.assertIsInstance(x, libcellml.NamedEntity)
         self.assertIsInstance(x, libcellml.Entity)
-        
+
         # Test access to inherited methods
         x = Units()
         idx = 'test'
@@ -31,9 +32,10 @@ class UnitsTestCase(unittest.TestCase):
         self.assertEqual(x.getId(), idx)
         y = Units(x)
         self.assertEqual(y.getId(), idx)
-        del(x, y, idx)
-        
-        # Test standard units
+
+    def test_standard_unit(self):
+        from libcellml import Units
+
         u = Units()
         u.addUnit(Units.StandardUnit.AMPERE)
         u.addUnit(Units.StandardUnit.BECQUEREL)
@@ -68,10 +70,15 @@ class UnitsTestCase(unittest.TestCase):
         u.addUnit(Units.StandardUnit.VOLT)
         u.addUnit(Units.StandardUnit.WATT)
         u.addUnit(Units.StandardUnit.WEBER)
-        self.assertRaises(RuntimeError, u.addUnit, Units.StandardUnit.AMPERE -1)
-        self.assertRaises(RuntimeError, u.addUnit, Units.StandardUnit.WEBER + 1)
-        
-        # Test prefixes
+        self.assertRaises(
+            RuntimeError, u.addUnit, Units.StandardUnit.AMPERE - 1)
+        self.assertRaises(
+            RuntimeError, u.addUnit, Units.StandardUnit.WEBER + 1)
+
+    def test_prefix(self):
+        from libcellml import Units
+
+        u = Units()
         u.addUnit('test', Units.Prefix.YOTTA)
         u.addUnit('test', Units.Prefix.ZETTA)
         u.addUnit('test', Units.Prefix.EXA)
@@ -92,18 +99,23 @@ class UnitsTestCase(unittest.TestCase):
         u.addUnit('test', Units.Prefix.ATTO)
         u.addUnit('test', Units.Prefix.ZEPTO)
         u.addUnit('test', Units.Prefix.YOCTO)
-        self.assertRaises(RuntimeError, u.addUnit, 'test', Units.Prefix.YOTTA - 1)
-        self.assertRaises(RuntimeError, u.addUnit, 'test', Units.Prefix.YOCTO + 1)
+        self.assertRaises(
+            RuntimeError, u.addUnit, 'test', Units.Prefix.YOTTA - 1)
+        self.assertRaises(
+            RuntimeError, u.addUnit, 'test', Units.Prefix.YOCTO + 1)
 
-        # Test own methods
-        
+    def test_is_base_unit(self):
+        from libcellml import Units
+
         # bool isBaseUnit()
         u = Units()
         self.assertTrue(u.isBaseUnit())
         u.addUnit(Units.StandardUnit.NEWTON)
         self.assertFalse(u.isBaseUnit())
-        del(u)
-        
+
+    def test_add_unit(self):
+        from libcellml import Units
+
         # void addUnit(const std::string &reference, const std::string &prefix,
         #   double exponent=1.0, double multiplier=1.0)
         u = Units()
@@ -114,7 +126,7 @@ class UnitsTestCase(unittest.TestCase):
         u.addUnit('a', 'b', 3, 3)
         u.addUnit('a', 'b', 0.1, -1.2)
         del(u)
-        
+
         # void addUnit(const std::string &reference, Prefix prefix,
         #   double exponent=1.0, double multiplier=1.0)
         u = Units()
@@ -125,7 +137,7 @@ class UnitsTestCase(unittest.TestCase):
         u.addUnit('a', Units.Prefix.YOTTA, -1, 2.3)
         u.addUnit('a', Units.Prefix.YOTTA, 1.2, 3.4)
         del(u)
-        
+
         # void addUnit(const std::string &reference, double prefix,
         #   double exponent, double multiplier=1.0)
         u = Units()
@@ -134,27 +146,27 @@ class UnitsTestCase(unittest.TestCase):
         u.addUnit('a', 1.2, -1, 3)
         u.addUnit('a', 1.2, -1, 2.3)
         u.addUnit('a', 1.2, 1.2, 3.4)
-        #TODO Ints get converted to Prefix enum, not to double!
-        #u.addUnit('a', -1, -1)
-        #u.addUnit('a', -1, 2.3)
-        #u.addUnit('a', -1, -1, 3)
-        #u.addUnit('a', -1, -1, 2.3)
-        #u.addUnit('a', -1, 1.2, 3.4)
+        # TODO Ints get converted to Prefix enum, not to double!
+        # u.addUnit('a', -1, -1)
+        # u.addUnit('a', -1, 2.3)
+        # u.addUnit('a', -1, -1, 3)
+        # u.addUnit('a', -1, -1, 2.3)
+        # u.addUnit('a', -1, 1.2, 3.4)
         del(u)
-        
+
         # void addUnit(const std::string &reference, double exponent)
         u = Units()
         u.addUnit('a', 1.0)
-        #TODO Ints get converted to Prefix enum, not to double!
-        #u.addUnit('a', -1)
+        # TODO Ints get converted to Prefix enum, not to double!
+        # u.addUnit('a', -1)
         del(u)
-        
+
         # void addUnit(const std::string &reference)
         u = Units()
         u.addUnit('')
         u.addUnit('a')
         del(u)
-        
+
         # void addUnit(StandardUnit standardRef, const std::string &prefix,
         #   double exponent=1.0, double multiplier=1.0)
         u = Units()
@@ -165,7 +177,7 @@ class UnitsTestCase(unittest.TestCase):
         u.addUnit(Units.StandardUnit.KATAL, 'pico', 1, 2.0)
         u.addUnit(Units.StandardUnit.KATAL, 'pico', -1, 2)
         del(u)
-        
+
         # void addUnit(StandardUnit standardRef, Prefix prefix,
         #   double exponent=1.0, double multiplier=1.0)
         u = Units()
@@ -176,7 +188,7 @@ class UnitsTestCase(unittest.TestCase):
         u.addUnit(Units.StandardUnit.KATAL, Units.Prefix.PICO, 1, 2.0)
         u.addUnit(Units.StandardUnit.KATAL, Units.Prefix.PICO, -1, 2)
         del(u)
-        
+
         # void addUnit(StandardUnit standardRef, double prefix,
         #   double exponent, double multiplier=1.0)
         u = Units()
@@ -185,16 +197,19 @@ class UnitsTestCase(unittest.TestCase):
         u.addUnit(Units.StandardUnit.KATAL, 1.0, 1.0, 1.0)
         u.addUnit(Units.StandardUnit.KATAL, -1.0, -1.0, 1.0)
         del(u)
-        
+
         # void addUnit(StandardUnit standardRef, double exponent)
         # Hidden to avoid confusion with addUnit(StandardUnit, Prefix, double,
         # double)
-        
+
         # void addUnit(StandardUnit standardRef)
         u = Units()
         u.addUnit(Units.StandardUnit.KATAL)
         del(u)
-        
+
+    def test_get_unit_attributes(self):
+        from libcellml import Units
+
         # void getUnitAttributes(size_t index, std::string& reference,
         #   std::string &prefix, double &exponent, double &multiplier)
         u = Units()
@@ -209,7 +224,7 @@ class UnitsTestCase(unittest.TestCase):
         self.assertIsInstance(x, list)
         self.assertEqual(x, ['', '', 1.0, 1.0])
         del(u, x)
-        
+
         # void getUnitAttributes(const std::string &reference,
         #   std::string &prefix, double &exponent, double &multiplier) const;
         u = Units()
@@ -224,11 +239,14 @@ class UnitsTestCase(unittest.TestCase):
         self.assertIsInstance(x, list)
         self.assertEqual(x, ['few', 'bars', 4.3, 2.1])
         del(u, x)
-        
+
         # This method conflicts with getUnitAttributes(size_t, ...)
         # void getUnitAttributes(StandardUnit standardRef, std::string &prefix,
         #   double &exponent, double &multiplier) const;
-        
+
+    def test_remove_unit(self):
+        from libcellml import Units
+
         # bool removeUnit(size_t index)
         u = Units()
         self.assertFalse(u.removeUnit(0))
@@ -240,7 +258,7 @@ class UnitsTestCase(unittest.TestCase):
         self.assertTrue(u.removeUnit(0))
         self.assertFalse(u.removeUnit(0))
         del(u)
-        
+
         # bool removeUnit(const std::string &reference)
         u = Units()
         self.assertFalse(u.removeUnit('hello'))
@@ -250,9 +268,12 @@ class UnitsTestCase(unittest.TestCase):
         self.assertFalse(u.removeUnit('hello'))
         del(u)
 
-        # This method conflicts with removeUnit(size_t)        
+        # This method conflicts with removeUnit(size_t)
         # bool removeUnit(StandardUnit standardRef)
-        
+
+    def test_unit_count(self):
+        from libcellml import Units
+
         # size_t unitCount()
         u = Units()
         self.assertEqual(u.unitCount(), 0)
@@ -260,8 +281,10 @@ class UnitsTestCase(unittest.TestCase):
         self.assertEqual(u.unitCount(), 1)
         u.addUnit('')
         self.assertEqual(u.unitCount(), 2)
-        del(u)
-        
+
+    def test_remove_all_units(self):
+        from libcellml import Units
+
         # void removeAllUnits()
         u = Units()
         self.assertEqual(u.unitCount(), 0)
@@ -271,14 +294,15 @@ class UnitsTestCase(unittest.TestCase):
         self.assertEqual(u.unitCount(), 2)
         u.removeAllUnits()
         self.assertEqual(u.unitCount(), 0)
-        del(u)
-        
+
+    def test_set_source_units(self):
+        from libcellml import Units, ImportSource
+
         # void setSourceUnits(const ImportPtr &imp, const std::string &name)
-        from libcellml import ImportSource
         i = ImportSource()
         u = Units()
         u.setSourceUnits(i, 'hello')
-        del(u, i)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_validator.py
+++ b/tests/bindings/python/test_validator.py
@@ -1,40 +1,43 @@
 #
 # Tests the Validator class bindings
 #
-import sys
 import unittest
+
 
 class ValidatorTestCase(unittest.TestCase):
 
-    def test_validator(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Validator
-        
-        # Test create/copy/destroy
+
         x = Validator()
         del(x)
         y = Validator()
         z = Validator(y)
         del(y, z)
-        
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import Validator
+
         # Test inheritance
         x = Validator()
         self.assertIsInstance(x, libcellml.Logger)
 
         # Test access to inherited methods
-        idx = 'test'
         self.assertIsNone(x.getError(0))
         self.assertIsNone(x.getError(-1))
         self.assertEqual(x.errorCount(), 0)
         x.addError(libcellml.Error())
         self.assertEqual(x.errorCount(), 1)
-        del(x, idx)
-        
-        # Test own methods
-        
+
+    def test_validate_model(self):
+        import libcellml
+        from libcellml import Validator
+
         # void validateModel(const ModelPtr &model)
         v = Validator()
         v.validateModel(libcellml.Model())
-        
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_variable.py
+++ b/tests/bindings/python/test_variable.py
@@ -1,27 +1,28 @@
 #
 # Tests the Variable class bindings
 #
-import sys
 import unittest
+
 
 class VariableTestCase(unittest.TestCase):
 
-    def test_variable(self):
-        import libcellml
+    def test_create_destroy(self):
         from libcellml import Variable
-        
-        # Test create/copy/destroy
+
         x = Variable()
         del(x)
         y = Variable()
         z = Variable(y)
         del(y, z)
-        
-        # Test inheritance
+
+    def test_inheritance(self):
+        import libcellml
+        from libcellml import Variable
+
         x = Variable()
         self.assertIsInstance(x, libcellml.NamedEntity)
         self.assertIsInstance(x, libcellml.Entity)
-        
+
         # Test access to inherited methods
         x = Variable()
         idx = 'test'
@@ -30,17 +31,19 @@ class VariableTestCase(unittest.TestCase):
         self.assertEqual(x.getId(), idx)
         y = Variable(x)
         self.assertEqual(y.getId(), idx)
-        del(x, y, idx)
-        
-        # Test own methods
+
+    def test_add_equivalence(self):
+        from libcellml import Variable
 
         # static void addEquivalence(const VariablePtr &variable1,
         #   const VariablePtr &variable2)
         v1 = Variable()
         v2 = Variable()
         Variable.addEquivalence(v1, v2)
-        del(v1, v2)
-        
+
+    def test_remove_equivalence(self):
+        from libcellml import Variable
+
         # static bool removeEquivalence(const VariablePtr &variable1,
         #   const VariablePtr &variable2)
         v1 = Variable()
@@ -54,8 +57,10 @@ class VariableTestCase(unittest.TestCase):
         self.assertFalse(Variable.removeEquivalence(v1, v2))
         Variable.addEquivalence(v1, v2)
         self.assertTrue(Variable.removeEquivalence(v2, v1))
-        del(v1, v2, v3)
-        
+
+    def test_remove_all_equivalences(self):
+        from libcellml import Variable
+
         # void removeAllEquivalences()
         v1 = Variable()
         v2 = Variable()
@@ -65,8 +70,10 @@ class VariableTestCase(unittest.TestCase):
         v2.removeAllEquivalences()
         self.assertFalse(Variable.removeEquivalence(v1, v2))
         self.assertTrue(Variable.removeEquivalence(v1, v3))
-        del(v1, v2, v3)
-        
+
+    def test_get_equivalent_variable(self):
+        from libcellml import Variable
+
         # VariablePtr getEquivalentVariable(size_t index)
         v1 = Variable()
         v2 = Variable()
@@ -80,8 +87,10 @@ class VariableTestCase(unittest.TestCase):
         self.assertIsNone(v1.getEquivalentVariable(-1))
         self.assertIsNotNone(v1.getEquivalentVariable(0))
         self.assertIsNotNone(v1.getEquivalentVariable(1))
-        del(v1, v2, v3)
-        
+
+    def test_equivalent_variable_count(self):
+        from libcellml import Variable
+
         # size_t equivalentVariableCount()
         v1 = Variable()
         v2 = Variable()
@@ -94,8 +103,10 @@ class VariableTestCase(unittest.TestCase):
         self.assertEqual(v1.equivalentVariableCount(), 1)
         self.assertEqual(v2.equivalentVariableCount(), 2)
         self.assertEqual(v3.equivalentVariableCount(), 1)
-        del(v1, v2, v3)
-        
+
+    def test_has_equivalent_variable(self):
+        from libcellml import Variable
+
         # bool hasEquivalentVariable(const VariablePtr &equivalentVariable)
         v1 = Variable()
         v2 = Variable()
@@ -114,15 +125,28 @@ class VariableTestCase(unittest.TestCase):
         self.assertFalse(v3.hasEquivalentVariable(v1))
         self.assertTrue(v3.hasEquivalentVariable(v2))
         self.assertFalse(v3.hasEquivalentVariable(v3))
-        del(v1, v2, v3)
-        
+
+    def test_set_units(self):
+        from libcellml import Variable, Units
+
         # void setUnits(const std::string &name)
         v = Variable()
         v.setUnits('')
         v.setUnits('Hello')
         v.setUnits('')
         del(v)
-        
+
+        # void setUnits(const UnitsPtr &units)
+        name = 'tiger'
+        u = Units()
+        u.setName(name)
+        v = Variable()
+        v.setUnits(u)
+        self.assertEqual(v.getUnits(), name)
+
+    def test_get_units(self):
+        from libcellml import Variable
+
         # std::string getUnits()
         name = 'testo'
         v = Variable()
@@ -132,32 +156,28 @@ class VariableTestCase(unittest.TestCase):
         v.setUnits('')
         self.assertEqual(v.getUnits(), '')
         del(v, name)
-        
-        # void setUnits(const UnitsPtr &units)
-        from libcellml import Units
-        name = 'tiger'
-        u = Units()
-        u.setName(name)
-        v = Variable()
-        v.setUnits(u)
-        self.assertEqual(v.getUnits(), name)
-        del(v, u, name)
+
+    def test_set_initial_value(self):
+        from libcellml import Variable
 
         # void setInitialValue(const std::string &initialValue)
         v = Variable()
         v.setInitialValue('test')
         del(v)
-        
+
         # void setInitialValue(double initialValue)
         v = Variable()
         v.setInitialValue('test')
         del(v)
-        
+
         # void setInitialValue(const VariablePtr &variable)
         v1 = Variable()
         v2 = Variable()
         v1.setInitialValue(v2)
         del(v1, v2)
+
+    def test_get_initial_value(self):
+        from libcellml import Variable
 
         # std::string getInitialValue()
         value = '5 + x'
@@ -165,13 +185,10 @@ class VariableTestCase(unittest.TestCase):
         self.assertEqual(v.getInitialValue(), '')
         v.setInitialValue(value)
         self.assertEqual(v.getInitialValue(), value)
-        del(v, value)
 
-        # void setInterfaceType(const std::string &interfaceType)
-        v = Variable()
-        v.setInterfaceType('special type')
-        del(v)
-        
+    def test_interface_type(self):
+        from libcellml import Variable
+
         # InterfaceType
         self.assertNotEqual(
             Variable.InterfaceType.NONE,
@@ -181,16 +198,24 @@ class VariableTestCase(unittest.TestCase):
             Variable.InterfaceType.PUBLIC,
             Variable.InterfaceType.PUBLIC_AND_PRIVATE,
             )
-        
+
+    def test_set_interface_type(self):
+        from libcellml import Variable
+
+        # void setInterfaceType(const std::string &interfaceType)
+        v = Variable()
+        v.setInterfaceType('special type')
+
         # void setInterfaceType(InterfaceType interfaceType)
         v = Variable()
         v.setInterfaceType(Variable.InterfaceType.NONE)
         v.setInterfaceType(Variable.InterfaceType.PRIVATE)
         v.setInterfaceType(Variable.InterfaceType.PUBLIC)
         v.setInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE)
-        self.assertRaises(RuntimeError, v.setInterfaceType,
-            Variable.InterfaceType.NONE - 1)
-        self.assertRaises(RuntimeError, v.setInterfaceType,
+        self.assertRaises(
+            RuntimeError, v.setInterfaceType, Variable.InterfaceType.NONE - 1)
+        self.assertRaises(
+            RuntimeError, v.setInterfaceType,
             Variable.InterfaceType.PUBLIC_AND_PRIVATE + 1)
         del(v)
 
@@ -198,7 +223,10 @@ class VariableTestCase(unittest.TestCase):
         v = Variable()
         v.setInterfaceType('not an interface type')
         del(v)
-        
+
+    def test_get_interface_type(self):
+        from libcellml import Variable
+
         # std::string getInterfaceType()
         v = Variable()
         self.assertEqual(v.getInterfaceType(), '')
@@ -210,7 +238,7 @@ class VariableTestCase(unittest.TestCase):
         self.assertEqual(v.getInterfaceType(), 'public')
         v.setInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE)
         self.assertEqual(v.getInterfaceType(), 'public_and_private')
-        del(v)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/bindings/python/test_version.py
+++ b/tests/bindings/python/test_version.py
@@ -1,21 +1,22 @@
 #
 # Tests the version function bindings
 #
-import sys
 import unittest
+
 
 class VersionTestCase(unittest.TestCase):
 
-    def test_validator(self):
+    def test_version(self):
         import libcellml
-        
+
         # unsigned int version()
         self.assertIsInstance(libcellml.version(), int)
         self.assertGreater(libcellml.version(), 0)
-        
+
         # const std::string versionString()
         self.assertIsInstance(libcellml.versionString(), str)
         self.assertNotEqual(libcellml.versionString(), '')
-        
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This splits the Python tests into smaller chunks, removing the need for lots of `del()` statements and improving legibility.
In addition, it tidies up the test code and bit, makes it pep8 compliant, and removes some unnecessary imports.