### PR TITLE
Update the XmlNode and XmlAttribute type methods.

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1128,7 +1128,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
 {
     XmlAttributePtr attribute = node->getFirstAttribute();
     while (attribute) {
-        if (attribute->isType(XLINK_NS, "href")) {
+        if (attribute->isType("href", XLINK_NS)) {
             importSource->setUrl(attribute->getValue());
         } else if (attribute->isType("id")) {
             importSource->setId(attribute->getValue());

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -250,9 +250,9 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
         err->setKind(Error::Kind::XML);
         mParser->addError(err);
         return;
-    } else if (!node->isType("model")) {
+    } else if (!node->isCellmlElement("model")) {
         ErrorPtr err = std::make_shared<Error>();
-        if (node->getType() == "model") {
+        if (node->getName() == "model") {
             std::string nodeNamespace = node->getNamespace();
             if (nodeNamespace.empty())
                 nodeNamespace = "null";
@@ -260,7 +260,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
                                 "'. A valid CellML root node should be in namespace '" + CELLML_2_0_NS +
                                 "'.");
         } else {
-            err->setDescription("Model element is of invalid type '" + node->getType() +
+            err->setDescription("Model element is of invalid type '" + node->getName() +
                                 "'. A valid CellML root node should be of type 'model'.");
         }
         err->setModel(model);
@@ -278,7 +278,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Model '" + node->getAttribute("name") +
-                                "' has an invalid attribute '" + attribute->getType() + "'.");
+                                "' has an invalid attribute '" + attribute->getName() + "'.");
             err->setModel(model);
             mParser->addError(err);
         }
@@ -289,18 +289,18 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
     std::vector<XmlNodePtr> connectionNodes;
     std::vector<XmlNodePtr> encapsulationNodes;
     while (childNode) {
-        if (childNode->isType("component")) {
+        if (childNode->isCellmlElement("component")) {
             ComponentPtr component = std::make_shared<Component>();
             loadComponent(component, childNode);
             model->addComponent(component);
-        } else if (childNode->isType("units")) {
+        } else if (childNode->isCellmlElement("units")) {
             UnitsPtr units = std::make_shared<Units>();
             loadUnits(units, childNode);
             model->addUnits(units);
-        } else if (childNode->isType("import")) {
+        } else if (childNode->isCellmlElement("import")) {
             ImportSourcePtr importSource = std::make_shared<ImportSource>();
             loadImport(importSource, model, childNode);
-        } else if (childNode->isType("encapsulation")) {
+        } else if (childNode->isCellmlElement("encapsulation")) {
             // An encapsulation should not have attributes other than an 'id' attribute.
             if (childNode->getFirstAttribute()) {
                 XmlAttributePtr attribute = childNode->getFirstAttribute();
@@ -310,7 +310,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
                     } else {
                         ErrorPtr err = std::make_shared<Error>();
                         err->setDescription("Encapsulation in model '" + model->getName() +
-                                            "' has an invalid attribute '" + attribute->getType() + "'.");
+                                            "' has an invalid attribute '" + attribute->getName() + "'.");
                         err->setModel(model);
                         err->setKind(Error::Kind::ENCAPSULATION);
                         mParser->addError(err);
@@ -333,7 +333,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
                 err->setRule(SpecificationRule::ENCAPSULATION_COMPONENT_REF);
                 mParser->addError(err);
             }
-        } else if (childNode->isType("connection")) {
+        } else if (childNode->isCellmlElement("connection")) {
             connectionNodes.push_back(childNode);
         } else if (childNode->isTextNode()) {
             std::string textNode = childNode->convertToString();
@@ -351,7 +351,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Model '" + model->getName() +
-                                "' has an invalid child element '" + childNode->getType() + "'.");
+                                "' has an invalid child element '" + childNode->getName() + "'.");
             err->setModel(model);
             err->setRule(SpecificationRule::MODEL_CHILD);
             mParser->addError(err);
@@ -387,7 +387,7 @@ void Parser::ParserImpl::loadComponent(const ComponentPtr &component, const XmlN
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Component '" + node->getAttribute("name") +
-                                "' has an invalid attribute '" + attribute->getType() + "'.");
+                                "' has an invalid attribute '" + attribute->getName() + "'.");
             err->setComponent(component);
             mParser->addError(err);
         }
@@ -395,15 +395,15 @@ void Parser::ParserImpl::loadComponent(const ComponentPtr &component, const XmlN
     }
     XmlNodePtr childNode = node->getFirstChild();
     while (childNode) {
-        if (childNode->isType("variable")) {
+        if (childNode->isCellmlElement("variable")) {
             VariablePtr variable = std::make_shared<Variable>();
             loadVariable(variable, childNode);
             component->addVariable(variable);
-        } else if (childNode->isType("reset")) {
+        } else if (childNode->isCellmlElement("reset")) {
             ResetPtr reset = std::make_shared<Reset>();
             loadReset(reset, component, childNode);
             component->addReset(reset);
-        } else if (childNode->isType(MATHML_NS, "math")) {
+        } else if (childNode->isElement(MATHML_NS, "math")) {
             // TODO: copy any namespaces declared in parents into the math element
             //       so math is a valid subdocument.
             std::string math = childNode->convertToString();
@@ -424,7 +424,7 @@ void Parser::ParserImpl::loadComponent(const ComponentPtr &component, const XmlN
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Component '" + component->getName() +
-                                "' has an invalid child element '" + childNode->getType() + "'.");
+                                "' has an invalid child element '" + childNode->getName() + "'.");
             err->setComponent(component);
             err->setRule(SpecificationRule::COMPONENT_CHILD);
             mParser->addError(err);
@@ -444,7 +444,7 @@ void Parser::ParserImpl::loadUnits(const UnitsPtr &units, const XmlNodePtr &node
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Units '" + units->getName() +
-                                "' has an invalid attribute '" + attribute->getType() + "'.");
+                                "' has an invalid attribute '" + attribute->getName() + "'.");
             err->setUnits(units);
             mParser->addError(err);
         }
@@ -452,7 +452,7 @@ void Parser::ParserImpl::loadUnits(const UnitsPtr &units, const XmlNodePtr &node
     }
     XmlNodePtr childNode = node->getFirstChild();
     while (childNode) {
-        if (childNode->isType("unit")) {
+        if (childNode->isCellmlElement("unit")) {
             loadUnit(units, childNode);
         } else if (childNode->isTextNode()) {
             std::string textNode = childNode->convertToString();
@@ -470,7 +470,7 @@ void Parser::ParserImpl::loadUnits(const UnitsPtr &units, const XmlNodePtr &node
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Units '" + units->getName() +
-                                "' has an invalid child element '" + childNode->getType() + "'.");
+                                "' has an invalid child element '" + childNode->getName() + "'.");
             err->setUnits(units);
             err->setRule(SpecificationRule::UNITS_CHILD);
             mParser->addError(err);
@@ -507,7 +507,7 @@ void Parser::ParserImpl::loadUnit(const UnitsPtr &units, const XmlNodePtr &node)
                 ErrorPtr err = std::make_shared<Error>();
                 err->setDescription("Unit referencing '" + node->getAttribute("units") +
                                     "' in units '" + units->getName() +
-                                    "' has an invalid child element '" + childNode->getType() + "'.");
+                                    "' has an invalid child element '" + childNode->getName() + "'.");
                 err->setUnits(units);
                 mParser->addError(err);
             }
@@ -553,7 +553,7 @@ void Parser::ParserImpl::loadUnit(const UnitsPtr &units, const XmlNodePtr &node)
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Unit referencing '" + node->getAttribute("units") +
                                 "' in units '" + units->getName() +
-                                "' has an invalid attribute '" + attribute->getType() + "'.");
+                                "' has an invalid attribute '" + attribute->getName() + "'.");
             err->setUnits(units);
             err->setRule(SpecificationRule::UNIT_OPTIONAL_ATTRIBUTE);
             mParser->addError(err);
@@ -585,7 +585,7 @@ void Parser::ParserImpl::loadVariable(const VariablePtr &variable, const XmlNode
             } else {
                 ErrorPtr err = std::make_shared<Error>();
                 err->setDescription("Variable '" + node->getAttribute("name") +
-                                    "' has an invalid child element '" + childNode->getType() + "'.");
+                                    "' has an invalid child element '" + childNode->getName() + "'.");
                 err->setVariable(variable);
                 mParser->addError(err);
             }
@@ -611,7 +611,7 @@ void Parser::ParserImpl::loadVariable(const VariablePtr &variable, const XmlNode
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Variable '" + node->getAttribute("name") +
-                                "' has an invalid attribute '" + attribute->getType() + "'.");
+                                "' has an invalid attribute '" + attribute->getName() + "'.");
             err->setVariable(variable);
             mParser->addError(err);
         }
@@ -665,7 +665,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Connection in model '" + model->getName() +
-                                "' has an invalid connection attribute '" + attribute->getType() + "'.");
+                                "' has an invalid connection attribute '" + attribute->getName() + "'.");
             err->setModel(model);
             err->setKind(Error::Kind::CONNECTION);
             mParser->addError(err);
@@ -728,15 +728,15 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
             } else {
                 ErrorPtr err = std::make_shared<Error>();
                 err->setDescription("Connection in model '" + model->getName() +
-                                    "' has an invalid child element '" + grandchildNode->getType() +
-                                    "' of element '" + childNode->getType() + "'.");
+                                    "' has an invalid child element '" + grandchildNode->getName() +
+                                    "' of element '" + childNode->getName() + "'.");
                 err->setModel(model);
                 err->setKind(Error::Kind::CONNECTION);
                 mParser->addError(err);
             }
         }
 
-        if (childNode->isType("map_variables")) {
+        if (childNode->isCellmlElement("map_variables")) {
             std::string variable1Name = "";
             std::string variable2Name = "";
             XmlAttributePtr attribute = childNode->getFirstAttribute();
@@ -750,7 +750,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
                 } else {
                     ErrorPtr err = std::make_shared<Error>();
                     err->setDescription("Connection in model '" + model->getName() +
-                                        "' has an invalid map_variables attribute '" + attribute->getType() + "'.");
+                                        "' has an invalid map_variables attribute '" + attribute->getName() + "'.");
                     err->setModel(model);
                     err->setKind(Error::Kind::CONNECTION);
                     mParser->addError(err);
@@ -799,7 +799,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Connection in model '" + model->getName() +
-                                "' has an invalid child element '" + childNode->getType() + "'.");
+                                "' has an invalid child element '" + childNode->getName() + "'.");
             err->setModel(model);
             err->setKind(Error::Kind::CONNECTION);
             mParser->addError(err);
@@ -928,7 +928,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
         ComponentPtr parentComponent = nullptr;
         std::string parentComponentName;
         std::string encapsulationId = "";
-        if (parentComponentNode->isType("component_ref")) {
+        if (parentComponentNode->isCellmlElement("component_ref")) {
             // Check for a component in the parent component_ref.
             XmlAttributePtr attribute = parentComponentNode->getFirstAttribute();
             while (attribute) {
@@ -952,7 +952,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
                 } else {
                     ErrorPtr err = std::make_shared<Error>();
                     err->setDescription("Encapsulation in model '" + model->getName() +
-                                        "' has an invalid component_ref attribute '" + attribute->getType() + "'.");
+                                        "' has an invalid component_ref attribute '" + attribute->getName() + "'.");
                     err->setModel(model);
                     err->setKind(Error::Kind::ENCAPSULATION);
                     err->setRule(SpecificationRule::COMPONENT_REF_COMPONENT_ATTRIBUTE);
@@ -990,7 +990,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Encapsulation in model '" + model->getName() +
-                                "' has an invalid child element '" + parentComponentNode->getType() + "'.");
+                                "' has an invalid child element '" + parentComponentNode->getName() + "'.");
             err->setModel(model);
             err->setKind(Error::Kind::ENCAPSULATION);
             err->setRule(SpecificationRule::ENCAPSULATION_COMPONENT_REF);
@@ -1001,7 +1001,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
         XmlNodePtr childComponentNode = parentComponentNode->getFirstChild();
         if (!childComponentNode) {
             XmlNodePtr grandParentComponentNode = parentComponentNode->getParent();
-            if (grandParentComponentNode->isType("encapsulation")) {
+            if (grandParentComponentNode->isCellmlElement("encapsulation")) {
                 ErrorPtr err = std::make_shared<Error>();
                 if (parentComponent) {
                     err->setDescription("Encapsulation in model '" + model->getName() +
@@ -1021,7 +1021,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
         std::string childEncapsulationId = "";
         while (childComponentNode) {
             ComponentPtr childComponent = nullptr;
-            if (childComponentNode->isType("component_ref")) {
+            if (childComponentNode->isCellmlElement("component_ref")) {
                 bool childComponentMissing = false;
                 bool foundChildComponent = false;
                 XmlAttributePtr attribute = childComponentNode->getFirstAttribute();
@@ -1047,7 +1047,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
                     } else {
                         ErrorPtr err = std::make_shared<Error>();
                         err->setDescription("Encapsulation in model '" + model->getName() +
-                                            "' has an invalid component_ref attribute '" + attribute->getType() + "'.");
+                                            "' has an invalid component_ref attribute '" + attribute->getName() + "'.");
                         err->setModel(model);
                         err->setKind(Error::Kind::ENCAPSULATION);
                         mParser->addError(err);
@@ -1092,7 +1092,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
             } else {
                 ErrorPtr err = std::make_shared<Error>();
                 err->setDescription("Encapsulation in model '" + model->getName() +
-                                    "' has an invalid child element '" + childComponentNode->getType() + "'.");
+                                    "' has an invalid child element '" + childComponentNode->getName() + "'.");
                 err->setModel(model);
                 err->setKind(Error::Kind::ENCAPSULATION);
                 err->setRule(SpecificationRule::COMPONENT_REF_CHILD);
@@ -1137,7 +1137,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Import from '" + node->getAttribute("href") +
-                                "' has an invalid attribute '" + attribute->getType() + "'.");
+                                "' has an invalid attribute '" + attribute->getName() + "'.");
             err->setImportSource(importSource);
             mParser->addError(err);
         }
@@ -1145,7 +1145,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
     }
     XmlNodePtr childNode = node->getFirstChild();
     while (childNode) {
-        if (childNode->isType("component")) {
+        if (childNode->isCellmlElement("component")) {
             ComponentPtr importedComponent = std::make_shared<Component>();
             bool errorOccurred = false;
             XmlAttributePtr attribute = childNode->getFirstAttribute();
@@ -1160,7 +1160,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
                     ErrorPtr err = std::make_shared<Error>();
                     err->setDescription("Import of component '" + childNode->getAttribute("name") +
                                         "' from '" + node->getAttribute("href") +
-                                        "' has an invalid attribute '" + attribute->getType() + "'.");
+                                        "' has an invalid attribute '" + attribute->getName() + "'.");
                     err->setImportSource(importSource);
                     mParser->addError(err);
                     errorOccurred = true;
@@ -1170,7 +1170,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
             if (!errorOccurred) {
                 model->addComponent(importedComponent);
             }
-        } else if (childNode->isType("units")) {
+        } else if (childNode->isCellmlElement("units")) {
             UnitsPtr importedUnits = std::make_shared<Units>();
             bool errorOccurred = false;
             XmlAttributePtr attribute = childNode->getFirstAttribute();
@@ -1185,7 +1185,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
                     ErrorPtr err = std::make_shared<Error>();
                     err->setDescription("Import of units '" + childNode->getAttribute("name") +
                                         "' from '" + node->getAttribute("href") +
-                                        "' has an invalid attribute '" + attribute->getType() + "'.");
+                                        "' has an invalid attribute '" + attribute->getName() + "'.");
                     err->setImportSource(importSource);
                     mParser->addError(err);
                     errorOccurred = true;
@@ -1211,7 +1211,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Import from '" + node->getAttribute("href") +
-                                "' has an invalid child element '" + childNode->getType() + "'.");
+                                "' has an invalid child element '" + childNode->getName() + "'.");
             err->setImportSource(importSource);
             err->setRule(SpecificationRule::IMPORT_CHILD);
             mParser->addError(err);
@@ -1265,7 +1265,7 @@ void Parser::ParserImpl::loadReset(const ResetPtr &reset, const ComponentPtr &co
         } else {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Reset in component '" + component->getName() +
-                                "' has an invalid attribute '" + attribute->getType() + "'.");
+                                "' has an invalid attribute '" + attribute->getName() + "'.");
             err->setReset(reset);
             mParser->addError(err);
         }
@@ -1298,7 +1298,7 @@ void Parser::ParserImpl::loadReset(const ResetPtr &reset, const ComponentPtr &co
 
     XmlNodePtr childNode = node->getFirstChild();
     while (childNode) {
-        if (childNode->isType("when")) {
+        if (childNode->isCellmlElement("when")) {
             WhenPtr when = std::make_shared<When>();
             loadWhen(when, reset, childNode);
             reset->addWhen(when);
@@ -1320,7 +1320,7 @@ void Parser::ParserImpl::loadReset(const ResetPtr &reset, const ComponentPtr &co
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Reset in component '" + component->getName() +
                                 "' referencing variable '" + variableName +
-                                "' has an invalid child element '" + childNode->getType() + "'.");
+                                "' has an invalid child element '" + childNode->getName() + "'.");
             err->setReset(reset);
             err->setRule(SpecificationRule::RESET_CHILD);
             mParser->addError(err);
@@ -1356,7 +1356,7 @@ void Parser::ParserImpl::loadWhen(const WhenPtr &when, const ResetPtr &reset, co
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("When in reset referencing variable '" + referencedVariableName +
                                 "' with order '" + resetOrder +
-                                "' has an invalid attribute '" + attribute->getType() + "'.");
+                                "' has an invalid attribute '" + attribute->getName() + "'.");
             err->setWhen(when);
             mParser->addError(err);
         }
@@ -1378,7 +1378,7 @@ void Parser::ParserImpl::loadWhen(const WhenPtr &when, const ResetPtr &reset, co
     size_t mathNodeCount = 0;
     XmlNodePtr childNode = node->getFirstChild();
     while (childNode) {
-        if (childNode->isType(MATHML_NS, "math")) {
+        if (childNode->isElement(MATHML_NS, "math")) {
             // TODO: copy any namespaces declared in parents into the math element
             //       so math is a valid subdocument.
             std::string math = childNode->convertToString();
@@ -1411,7 +1411,7 @@ void Parser::ParserImpl::loadWhen(const WhenPtr &when, const ResetPtr &reset, co
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("When in reset referencing variable '" + referencedVariableName +
                                 "' with order '" + resetOrder +
-                                "' has an invalid child element '" + childNode->getType() + "'.");
+                                "' has an invalid child element '" + childNode->getName() + "'.");
             err->setWhen(when);
             err->setRule(SpecificationRule::WHEN_CHILD);
             mParser->addError(err);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -335,7 +335,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
             }
         } else if (childNode->isCellmlElement("connection")) {
             connectionNodes.push_back(childNode);
-        } else if (childNode->isTextNode()) {
+        } else if (childNode->isText()) {
             std::string textNode = childNode->convertToString();
             // Ignore whitespace when parsing.
             if (hasNonWhitespaceCharacters(textNode)) {
@@ -346,7 +346,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
                 err->setRule(SpecificationRule::MODEL_CHILD);
                 mParser->addError(err);
             }
-        } else if (childNode->isCommentNode()) {
+        } else if (childNode->isComment()) {
             // Do nothing.
         } else {
             ErrorPtr err = std::make_shared<Error>();
@@ -408,7 +408,7 @@ void Parser::ParserImpl::loadComponent(const ComponentPtr &component, const XmlN
             //       so math is a valid subdocument.
             std::string math = childNode->convertToString();
             component->appendMath(math);
-        } else if (childNode->isTextNode()) {
+        } else if (childNode->isText()) {
             std::string textNode = childNode->convertToString();
             // Ignore whitespace when parsing.
             if (hasNonWhitespaceCharacters(textNode)) {
@@ -419,7 +419,7 @@ void Parser::ParserImpl::loadComponent(const ComponentPtr &component, const XmlN
                 err->setRule(SpecificationRule::COMPONENT_CHILD);
                 mParser->addError(err);
             }
-        } else if (childNode->isCommentNode()) {
+        } else if (childNode->isComment()) {
             // Do nothing.
         } else {
             ErrorPtr err = std::make_shared<Error>();
@@ -454,7 +454,7 @@ void Parser::ParserImpl::loadUnits(const UnitsPtr &units, const XmlNodePtr &node
     while (childNode) {
         if (childNode->isCellmlElement("unit")) {
             loadUnit(units, childNode);
-        } else if (childNode->isTextNode()) {
+        } else if (childNode->isText()) {
             std::string textNode = childNode->convertToString();
             // Ignore whitespace when parsing.
             if (hasNonWhitespaceCharacters(textNode)) {
@@ -465,7 +465,7 @@ void Parser::ParserImpl::loadUnits(const UnitsPtr &units, const XmlNodePtr &node
                 err->setRule(SpecificationRule::UNITS_CHILD);
                 mParser->addError(err);
             }
-        } else if (childNode->isCommentNode()) {
+        } else if (childNode->isComment()) {
             // Do nothing.
         } else {
             ErrorPtr err = std::make_shared<Error>();
@@ -490,7 +490,7 @@ void Parser::ParserImpl::loadUnit(const UnitsPtr &units, const XmlNodePtr &node)
     if (node->getFirstChild()) {
         XmlNodePtr childNode = node->getFirstChild();
         while (childNode) {
-            if (childNode->isTextNode()) {
+            if (childNode->isText()) {
                 std::string textNode = childNode->convertToString();
                 // Ignore whitespace when parsing.
                 if (hasNonWhitespaceCharacters(textNode)) {
@@ -501,7 +501,7 @@ void Parser::ParserImpl::loadUnit(const UnitsPtr &units, const XmlNodePtr &node)
                     err->setUnits(units);
                     mParser->addError(err);
                 }
-            } else if (childNode->isCommentNode()) {
+            } else if (childNode->isComment()) {
                 // Do nothing.
             } else {
                 ErrorPtr err = std::make_shared<Error>();
@@ -570,7 +570,7 @@ void Parser::ParserImpl::loadVariable(const VariablePtr &variable, const XmlNode
     if (node->getFirstChild()) {
         XmlNodePtr childNode = node->getFirstChild();
         while (childNode) {
-            if (childNode->isTextNode()) {
+            if (childNode->isText()) {
                 std::string textNode = childNode->convertToString();
                 // Ignore whitespace when parsing.
                 if (hasNonWhitespaceCharacters(textNode)) {
@@ -580,7 +580,7 @@ void Parser::ParserImpl::loadVariable(const VariablePtr &variable, const XmlNode
                     err->setVariable(variable);
                     mParser->addError(err);
                 }
-            } else if (childNode->isCommentNode()) {
+            } else if (childNode->isComment()) {
                 // Do nothing.
             } else {
                 ErrorPtr err = std::make_shared<Error>();
@@ -712,7 +712,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
         // Connection map XML nodes should not have further children.
         if (childNode->getFirstChild()) {
             XmlNodePtr grandchildNode = childNode->getFirstChild();
-            if (grandchildNode->isTextNode()) {
+            if (grandchildNode->isText()) {
                 std::string textNode = grandchildNode->convertToString();
                 // Ignore whitespace when parsing.
                 if (hasNonWhitespaceCharacters(textNode)) {
@@ -723,7 +723,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
                     err->setKind(Error::Kind::CONNECTION);
                     mParser->addError(err);
                 }
-            } else if (childNode->isCommentNode()) {
+            } else if (childNode->isComment()) {
                 // Do nothing.
             } else {
                 ErrorPtr err = std::make_shared<Error>();
@@ -783,7 +783,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
             variableNameMap.push_back(variableNamePair);
             mapVariablesFound = true;
 
-        } else if (childNode->isTextNode()) {
+        } else if (childNode->isText()) {
             const std::string textNode = childNode->convertToString();
             // Ignore whitespace when parsing.
             if (hasNonWhitespaceCharacters(textNode)) {
@@ -794,7 +794,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
                 err->setKind(Error::Kind::CONNECTION);
                 mParser->addError(err);
             }
-        } else if (childNode->isCommentNode()) {
+        } else if (childNode->isComment()) {
             // Do nothing.
         } else {
             ErrorPtr err = std::make_shared<Error>();
@@ -971,7 +971,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
             } else if (parentComponent) {
                 parentComponent->setEncapsulationId(encapsulationId);
             }
-        } else if (parentComponentNode->isTextNode()) {
+        } else if (parentComponentNode->isText()) {
             const std::string textNode = parentComponentNode->convertToString();
             // Ignore whitespace when parsing.
             if (hasNonWhitespaceCharacters(textNode)) {
@@ -1077,7 +1077,7 @@ void Parser::ParserImpl::loadEncapsulation(const ModelPtr &model, const XmlNodeP
                     childComponent->setEncapsulationId(childEncapsulationId );
                 }
 
-            } else if (childComponentNode->isTextNode()) {
+            } else if (childComponentNode->isText()) {
                 const std::string textNode = childComponentNode->convertToString();
                 // Ignore whitespace when parsing.
                 if (hasNonWhitespaceCharacters(textNode)) {
@@ -1195,7 +1195,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
             if (!errorOccurred) {
                 model->addUnits(importedUnits);
             }
-        } else if (childNode->isTextNode()) {
+        } else if (childNode->isText()) {
             const std::string textNode = childNode->convertToString();
             // Ignore whitespace when parsing.
             if (hasNonWhitespaceCharacters(textNode)) {
@@ -1206,7 +1206,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
                 err->setRule(SpecificationRule::IMPORT_CHILD);
                 mParser->addError(err);
             }
-        } else if (childNode->isCommentNode()) {
+        } else if (childNode->isComment()) {
             // Do nothing.
         } else {
             ErrorPtr err = std::make_shared<Error>();
@@ -1302,7 +1302,7 @@ void Parser::ParserImpl::loadReset(const ResetPtr &reset, const ComponentPtr &co
             WhenPtr when = std::make_shared<When>();
             loadWhen(when, reset, childNode);
             reset->addWhen(when);
-        } else if (childNode->isTextNode()) {
+        } else if (childNode->isText()) {
             const std::string textNode = childNode->convertToString();
             // Ignore whitespace when parsing.
             if (hasNonWhitespaceCharacters(textNode)) {
@@ -1314,7 +1314,7 @@ void Parser::ParserImpl::loadReset(const ResetPtr &reset, const ComponentPtr &co
                 err->setRule(SpecificationRule::RESET_CHILD);
                 mParser->addError(err);
             }
-        } else if (childNode->isCommentNode()) {
+        } else if (childNode->isComment()) {
             // Do nothing.
         } else {
             ErrorPtr err = std::make_shared<Error>();
@@ -1396,7 +1396,7 @@ void Parser::ParserImpl::loadWhen(const WhenPtr &when, const ResetPtr &reset, co
                 err->setRule(SpecificationRule::WHEN_CHILD);
                 mParser->addError(err);
             }
-        } else if (childNode->isTextNode()) {
+        } else if (childNode->isText()) {
             const std::string textNode = childNode->convertToString();
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("When in reset referencing variable '" + referencedVariableName +
@@ -1405,7 +1405,7 @@ void Parser::ParserImpl::loadWhen(const WhenPtr &when, const ResetPtr &reset, co
             err->setWhen(when);
             err->setRule(SpecificationRule::WHEN_CHILD);
             mParser->addError(err);
-        } else if (childNode->isCommentNode()) {
+        } else if (childNode->isComment()) {
             // Do nothing.
         } else {
             ErrorPtr err = std::make_shared<Error>();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -403,7 +403,7 @@ void Parser::ParserImpl::loadComponent(const ComponentPtr &component, const XmlN
             ResetPtr reset = std::make_shared<Reset>();
             loadReset(reset, component, childNode);
             component->addReset(reset);
-        } else if (childNode->isElement(MATHML_NS, "math")) {
+        } else if (childNode->isElement("math", MATHML_NS)) {
             // TODO: copy any namespaces declared in parents into the math element
             //       so math is a valid subdocument.
             std::string math = childNode->convertToString();
@@ -1378,7 +1378,7 @@ void Parser::ParserImpl::loadWhen(const WhenPtr &when, const ResetPtr &reset, co
     size_t mathNodeCount = 0;
     XmlNodePtr childNode = node->getFirstChild();
     while (childNode) {
-        if (childNode->isElement(MATHML_NS, "math")) {
+        if (childNode->isElement("math", MATHML_NS)) {
             // TODO: copy any namespaces declared in parents into the math element
             //       so math is a valid subdocument.
             std::string math = childNode->convertToString();

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -791,9 +791,9 @@ void Validator::ValidatorImpl::validateMath(const std::string &input, const Comp
         err->setComponent(component);
         mValidator->addError(err);
         return;
-    } else if (!node->isType(MATHML_NS, "math")) {
+    } else if (!node->isElement(MATHML_NS, "math")) {
         ErrorPtr err = std::make_shared<Error>();
-        err->setDescription("Math root node is of invalid type '" + node->getType() +
+        err->setDescription("Math root node is of invalid type '" + node->getName() +
                             "' on component '" + component->getName() +
                             "'. A valid math root node should be of type 'math'.");
         err->setComponent(component);
@@ -857,8 +857,8 @@ void Validator::ValidatorImpl::validateAndCleanMathCiCnNodes(XmlNodePtr &node, c
 {
     XmlNodePtr childNode = node->getFirstChild();
     std::string textNode;
-    bool ciType = node->isType(MATHML_NS, "ci");
-    bool cnType = node->isType(MATHML_NS, "cn");
+    bool ciType = node->isElement(MATHML_NS, "ci");
+    bool cnType = node->isElement(MATHML_NS, "cn");
     if (ciType || cnType) {
         if (childNode) {
             if (childNode->isTextNode()) {
@@ -883,7 +883,7 @@ void Validator::ValidatorImpl::validateAndCleanMathCiCnNodes(XmlNodePtr &node, c
                     }
                 } else {
                     ErrorPtr err = std::make_shared<Error>();
-                    err->setDescription("MathML " + node->getType() + " element has a whitespace-only child element.");
+                    err->setDescription("MathML " + node->getName() + " element has a whitespace-only child element.");
                     err->setComponent(component);
                     err->setKind(Error::Kind::MATHML);
                     mValidator->addError(err);
@@ -891,7 +891,7 @@ void Validator::ValidatorImpl::validateAndCleanMathCiCnNodes(XmlNodePtr &node, c
             }
         } else {
             ErrorPtr err = std::make_shared<Error>();
-            err->setDescription("MathML " + node->getType() + " element has no child.");
+            err->setDescription("MathML " + node->getName() + " element has no child.");
             err->setComponent(component);
             err->setKind(Error::Kind::MATHML);
             mValidator->addError(err);
@@ -907,8 +907,8 @@ void Validator::ValidatorImpl::validateAndCleanMathCiCnNodes(XmlNodePtr &node, c
                     unitsAttribute = attribute;
                 } else {
                     ErrorPtr err = std::make_shared<Error>();
-                    err->setDescription("Math " + node->getType() + " element has an invalid attribute type '" +
-                                        attribute->getType() + "' in the cellml namespace.");
+                    err->setDescription("Math " + node->getName() + " element has an invalid attribute type '" +
+                                        attribute->getName() + "' in the cellml namespace.");
                     err->setComponent(component);
                     err->setKind(Error::Kind::MATHML);
                     mValidator->addError(err);
@@ -946,7 +946,7 @@ void Validator::ValidatorImpl::validateAndCleanMathCiCnNodes(XmlNodePtr &node, c
                 // Check for a matching standard units.
                 if (!isStandardUnitName(unitsName)) {
                     ErrorPtr err = std::make_shared<Error>();
-                    err->setDescription("Math has a " + node->getType() + " element with a cellml:units attribute '" + unitsName +
+                    err->setDescription("Math has a " + node->getName() + " element with a cellml:units attribute '" + unitsName +
                                         "' that is not a valid reference to units in component '" +
                                         component->getName() + "' or a standard unit.");
                     err->setComponent(component);
@@ -980,7 +980,7 @@ void Validator::ValidatorImpl::validateMathMLElements(const XmlNodePtr &node, co
     if (childNode) {
         if (!childNode->isTextNode() && !isSupportedMathMLElement(childNode)) {
             ErrorPtr err = std::make_shared<Error>();
-            err->setDescription("Math has a '" + childNode->getType() + "' element" +
+            err->setDescription("Math has a '" + childNode->getName() + "' element" +
                                 " that is not a supported MathML element.");
             err->setComponent(component);
             err->setKind(Error::Kind::MATHML);
@@ -993,7 +993,7 @@ void Validator::ValidatorImpl::validateMathMLElements(const XmlNodePtr &node, co
     if (nextNode) {
         if (!nextNode->isTextNode() && !isSupportedMathMLElement(nextNode)) {
             ErrorPtr err = std::make_shared<Error>();
-            err->setDescription("Math has a '" + nextNode->getType() + "' element" +
+            err->setDescription("Math has a '" + nextNode->getName() + "' element" +
                                 " that is not a supported MathML element.");
             err->setComponent(component);
             err->setKind(Error::Kind::MATHML);
@@ -1006,8 +1006,8 @@ void Validator::ValidatorImpl::validateMathMLElements(const XmlNodePtr &node, co
 void Validator::ValidatorImpl::gatherMathBvarVariableNames(XmlNodePtr &node, std::vector<std::string> &bvarNames)
 {
     XmlNodePtr childNode = node->getFirstChild();
-    if (node->isType(MATHML_NS, "bvar")) {
-        if ((childNode) && (childNode->isType(MATHML_NS, "ci"))) {
+    if (node->isElement(MATHML_NS, "bvar")) {
+        if ((childNode) && (childNode->isElement(MATHML_NS, "ci"))) {
             XmlNodePtr grandchildNode = childNode->getFirstChild();
             if (grandchildNode) {
                 if (grandchildNode->isTextNode()) {
@@ -1097,7 +1097,7 @@ bool Validator::ValidatorImpl::isSupportedMathMLElement(const XmlNodePtr &node)
         "notanumber", "infinity", "true", "false"
     };
     return    !node->getNamespace().compare(MATHML_NS)
-           && std::find(supportedMathMLElements.begin(), supportedMathMLElements.end(), node->getType()) != supportedMathMLElements.end();
+           && std::find(supportedMathMLElements.begin(), supportedMathMLElements.end(), node->getName()) != supportedMathMLElements.end();
 }
 
 bool Validator::ValidatorImpl::isStandardUnitName(const std::string &name)

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -902,7 +902,7 @@ void Validator::ValidatorImpl::validateAndCleanMathCiCnNodes(XmlNodePtr &node, c
         XmlAttributePtr unitsAttribute = nullptr;
         while (attribute) {
             if (attribute->getValue().length() > 0) {
-                if (attribute->isType(CELLML_2_0_NS, "units")) {
+                if (attribute->isType("units", CELLML_2_0_NS)) {
                     unitsName = attribute->getValue();
                     unitsAttribute = attribute;
                 } else {

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -861,7 +861,7 @@ void Validator::ValidatorImpl::validateAndCleanMathCiCnNodes(XmlNodePtr &node, c
     bool cnType = node->isElement("cn", MATHML_NS);
     if (ciType || cnType) {
         if (childNode) {
-            if (childNode->isTextNode()) {
+            if (childNode->isText()) {
                 textNode = childNode->convertToString();
                 if (hasNonWhitespaceCharacters(textNode)) {
                     if (ciType) {
@@ -978,7 +978,7 @@ void Validator::ValidatorImpl::validateMathMLElements(const XmlNodePtr &node, co
 {
     XmlNodePtr childNode = node->getFirstChild();
     if (childNode) {
-        if (!childNode->isTextNode() && !isSupportedMathMLElement(childNode)) {
+        if (!childNode->isText() && !isSupportedMathMLElement(childNode)) {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Math has a '" + childNode->getName() + "' element" +
                                 " that is not a supported MathML element.");
@@ -991,7 +991,7 @@ void Validator::ValidatorImpl::validateMathMLElements(const XmlNodePtr &node, co
 
     XmlNodePtr nextNode = node->getNext();
     if (nextNode) {
-        if (!nextNode->isTextNode() && !isSupportedMathMLElement(nextNode)) {
+        if (!nextNode->isText() && !isSupportedMathMLElement(nextNode)) {
             ErrorPtr err = std::make_shared<Error>();
             err->setDescription("Math has a '" + nextNode->getName() + "' element" +
                                 " that is not a supported MathML element.");
@@ -1010,7 +1010,7 @@ void Validator::ValidatorImpl::gatherMathBvarVariableNames(XmlNodePtr &node, std
         if ((childNode) && (childNode->isElement("ci", MATHML_NS))) {
             XmlNodePtr grandchildNode = childNode->getFirstChild();
             if (grandchildNode) {
-                if (grandchildNode->isTextNode()) {
+                if (grandchildNode->isText()) {
                     std::string textNode = grandchildNode->convertToString();
                     if (hasNonWhitespaceCharacters(textNode)) {
                         bvarNames.push_back(textNode);

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -791,7 +791,7 @@ void Validator::ValidatorImpl::validateMath(const std::string &input, const Comp
         err->setComponent(component);
         mValidator->addError(err);
         return;
-    } else if (!node->isElement(MATHML_NS, "math")) {
+    } else if (!node->isElement("math", MATHML_NS)) {
         ErrorPtr err = std::make_shared<Error>();
         err->setDescription("Math root node is of invalid type '" + node->getName() +
                             "' on component '" + component->getName() +
@@ -857,8 +857,8 @@ void Validator::ValidatorImpl::validateAndCleanMathCiCnNodes(XmlNodePtr &node, c
 {
     XmlNodePtr childNode = node->getFirstChild();
     std::string textNode;
-    bool ciType = node->isElement(MATHML_NS, "ci");
-    bool cnType = node->isElement(MATHML_NS, "cn");
+    bool ciType = node->isElement("ci", MATHML_NS);
+    bool cnType = node->isElement("cn", MATHML_NS);
     if (ciType || cnType) {
         if (childNode) {
             if (childNode->isTextNode()) {
@@ -1006,8 +1006,8 @@ void Validator::ValidatorImpl::validateMathMLElements(const XmlNodePtr &node, co
 void Validator::ValidatorImpl::gatherMathBvarVariableNames(XmlNodePtr &node, std::vector<std::string> &bvarNames)
 {
     XmlNodePtr childNode = node->getFirstChild();
-    if (node->isElement(MATHML_NS, "bvar")) {
-        if ((childNode) && (childNode->isElement(MATHML_NS, "ci"))) {
+    if (node->isElement("bvar", MATHML_NS)) {
+        if ((childNode) && (childNode->isElement("ci", MATHML_NS))) {
             XmlNodePtr grandchildNode = childNode->getFirstChild();
             if (grandchildNode) {
                 if (grandchildNode->isTextNode()) {

--- a/src/xmlattribute.cpp
+++ b/src/xmlattribute.cpp
@@ -75,7 +75,7 @@ bool XmlAttribute::isType(const char *attributeName)
     return isType(NULL_NS, attributeName);
 }
 
-std::string XmlAttribute::getType() const
+std::string XmlAttribute::getName() const
 {
     std::string type;
     if (mPimpl->mXmlAttributePtr->name) {

--- a/src/xmlattribute.cpp
+++ b/src/xmlattribute.cpp
@@ -60,19 +60,14 @@ std::string XmlAttribute::getNamespace() const
     return std::string(reinterpret_cast<const char *>(mPimpl->mXmlAttributePtr->ns->href));
 }
 
-bool XmlAttribute::isType(const char *attributeNamespace, const char *attributeName)
+bool XmlAttribute::isType(const char *name, const char *ns)
 {
     bool found = false;
-    if (   !xmlStrcmp(BAD_CAST getNamespace().c_str(), BAD_CAST attributeNamespace)
-        && !xmlStrcmp(mPimpl->mXmlAttributePtr->name, BAD_CAST attributeName)) {
+    if (   !xmlStrcmp(BAD_CAST getNamespace().c_str(), BAD_CAST ns)
+        && !xmlStrcmp(mPimpl->mXmlAttributePtr->name, BAD_CAST name)) {
         found = true;
     }
     return found;
-}
-
-bool XmlAttribute::isType(const char *attributeName)
-{
-    return isType(NULL_NS, attributeName);
 }
 
 std::string XmlAttribute::getName() const

--- a/src/xmlattribute.h
+++ b/src/xmlattribute.h
@@ -66,31 +66,15 @@ public:
      * the given namespace.
      * Returns @ true if so, and @c false otherwise.
      *
-     * @param attributeNamespace The @c char namespace in which the attribute
+     * @param ns The @c char namespace in which the attribute
      * type name is to be defined.
-     * @param attributeName The @c char attribute type name to check for.
+     * @param name The @c char attribute type name to check for.
      *
      * @return @c true if this XmlAttribute is of the attribute type
-     * specified by the @p attributeName in the namespace @attributeNamespace
+     * specified by the @p name in the namespace @p ns
      * and @c false otherwise.
      */
-    bool isType(const char *attributeNamespace, const char *attributeName);
-
-    /**
-     * @brief Check if this XmlAttribute is of the named attribute type in the
-     * null namespace.
-     *
-     * Checks whether this XmlAttribute has the argument attribute type name in
-     * the null namespace.
-     * Returns @ true if so, and @c false otherwise.
-     *
-     * @param attributeName The @c char attribute type name to check for.
-     *
-     * @return @c true if this XmlAttribute is of the attribute type
-     * specified by the @p attributeName in the null namespace and @c false
-     * otherwise.
-     */
-    bool isType(const char *attributeName);
+    bool isType(const char *name, const char *ns = "");
 
     /**
      * @brief Get the name of this XmlAttribute.

--- a/src/xmlattribute.h
+++ b/src/xmlattribute.h
@@ -93,13 +93,13 @@ public:
     bool isType(const char *attributeName);
 
     /**
-     * @brief Get the type of this XmlAttribute.
+     * @brief Get the name of this XmlAttribute.
      *
-     * Gets the type of this XmlAttribute and returns it as a @c std::string.
+     * Gets the name of this XmlAttribute and returns it as a @c std::string.
      *
      * @return The @c std::string corresponding with the name of this XmlAttribute.
      */
-    std::string getType() const;
+    std::string getName() const;
 
     /**
      * @brief Get the value of this XmlAttribute.

--- a/src/xmlnode.cpp
+++ b/src/xmlnode.cpp
@@ -61,19 +61,20 @@ std::string XmlNode::getNamespace() const
     return std::string(reinterpret_cast<const char *>(mPimpl->mXmlNodePtr->ns->href));
 }
 
-bool XmlNode::isElement(const char *attributeNamespace, const char *elementName)
+bool XmlNode::isElement(const char *ns, const char *name)
 {
     bool found = false;
-    if (   !xmlStrcmp(BAD_CAST getNamespace().c_str(), BAD_CAST attributeNamespace)
-        && !xmlStrcmp(mPimpl->mXmlNodePtr->name, BAD_CAST elementName)) {
+    if ((mPimpl->mXmlNodePtr->type == XML_ELEMENT_NODE)
+		&& !xmlStrcmp(BAD_CAST getNamespace().c_str(), BAD_CAST ns)
+        && !xmlStrcmp(mPimpl->mXmlNodePtr->name, BAD_CAST name)) {
         found = true;
     }
     return found;
 }
 
-bool XmlNode::isCellmlElement(const char *elementName)
+bool XmlNode::isCellmlElement(const char *name)
 {
-    return isElement(CELLML_2_0_NS, elementName);
+    return isElement(CELLML_2_0_NS, name);
 }
 
 bool XmlNode::isTextNode()

--- a/src/xmlnode.cpp
+++ b/src/xmlnode.cpp
@@ -61,7 +61,7 @@ std::string XmlNode::getNamespace() const
     return std::string(reinterpret_cast<const char *>(mPimpl->mXmlNodePtr->ns->href));
 }
 
-bool XmlNode::isElement(const char *ns, const char *name)
+bool XmlNode::isElement(const char *name, const char *ns)
 {
     bool found = false;
     if ((mPimpl->mXmlNodePtr->type == XML_ELEMENT_NODE)
@@ -74,7 +74,7 @@ bool XmlNode::isElement(const char *ns, const char *name)
 
 bool XmlNode::isCellmlElement(const char *name)
 {
-    return isElement(CELLML_2_0_NS, name);
+    return isElement(name, CELLML_2_0_NS);
 }
 
 bool XmlNode::isTextNode()

--- a/src/xmlnode.cpp
+++ b/src/xmlnode.cpp
@@ -64,8 +64,8 @@ std::string XmlNode::getNamespace() const
 bool XmlNode::isElement(const char *name, const char *ns)
 {
     bool found = false;
-    if ((mPimpl->mXmlNodePtr->type == XML_ELEMENT_NODE)
-		&& !xmlStrcmp(BAD_CAST getNamespace().c_str(), BAD_CAST ns)
+    if (    (mPimpl->mXmlNodePtr->type == XML_ELEMENT_NODE)
+        && !xmlStrcmp(BAD_CAST getNamespace().c_str(), BAD_CAST ns)
         && !xmlStrcmp(mPimpl->mXmlNodePtr->name, BAD_CAST name)) {
         found = true;
     }

--- a/src/xmlnode.cpp
+++ b/src/xmlnode.cpp
@@ -61,7 +61,7 @@ std::string XmlNode::getNamespace() const
     return std::string(reinterpret_cast<const char *>(mPimpl->mXmlNodePtr->ns->href));
 }
 
-bool XmlNode::isType(const char *attributeNamespace, const char *elementName)
+bool XmlNode::isElement(const char *attributeNamespace, const char *elementName)
 {
     bool found = false;
     if (   !xmlStrcmp(BAD_CAST getNamespace().c_str(), BAD_CAST attributeNamespace)
@@ -71,9 +71,9 @@ bool XmlNode::isType(const char *attributeNamespace, const char *elementName)
     return found;
 }
 
-bool XmlNode::isType(const char *elementName)
+bool XmlNode::isCellmlElement(const char *elementName)
 {
-    return isType(CELLML_2_0_NS, elementName);
+    return isElement(CELLML_2_0_NS, elementName);
 }
 
 bool XmlNode::isTextNode()
@@ -86,7 +86,7 @@ bool XmlNode::isCommentNode()
     return mPimpl->mXmlNodePtr->type == XML_COMMENT_NODE;
 }
 
-std::string XmlNode::getType() const
+std::string XmlNode::getName() const
 {
     return std::string(reinterpret_cast<const char *>(mPimpl->mXmlNodePtr->name));
 }

--- a/src/xmlnode.cpp
+++ b/src/xmlnode.cpp
@@ -77,12 +77,12 @@ bool XmlNode::isCellmlElement(const char *name)
     return isElement(name, CELLML_2_0_NS);
 }
 
-bool XmlNode::isTextNode()
+bool XmlNode::isText()
 {
     return mPimpl->mXmlNodePtr->type == XML_TEXT_NODE;
 }
 
-bool XmlNode::isCommentNode()
+bool XmlNode::isComment()
 {
     return mPimpl->mXmlNodePtr->type == XML_COMMENT_NODE;
 }

--- a/src/xmlnode.h
+++ b/src/xmlnode.h
@@ -68,15 +68,15 @@ public:
 	 * given namespace with the specified local name.
      * Returns @c true if so, and @c false otherwise.
      *
+     * @param name The @c char element name to check for.
      * @param ns The @c char namespace in which the element
      * node is to be defined.
-     * @param name The @c char element name to check for.
      *
      * @return @c true if this @c XmlNode is an element node in the
 	 * given namespace @p ns with the given local name @p name;
      * and @c false otherwise.
      */
-    bool isElement(const char *ns, const char *name);
+    bool isElement(const char *name, const char *ns);
 
     /**
      * @brief Check if this @c XmlNode is an element node in the

--- a/src/xmlnode.h
+++ b/src/xmlnode.h
@@ -102,7 +102,7 @@ public:
      *
      * @return @c true if this @c XmlNode is a text node and @c false otherwise.
      */
-    bool isTextNode();
+    bool isText();
 
     /**
      * @brief Check if this @c XmlNode is a comment node.
@@ -113,7 +113,7 @@ public:
      * @return @c true if this @c XmlNode is a comment node and @c false
      * otherwise.
      */
-    bool isCommentNode();
+    bool isComment();
 
     /**
      * @brief Get the name of the XML element.

--- a/src/xmlnode.h
+++ b/src/xmlnode.h
@@ -61,38 +61,38 @@ public:
     std::string getNamespace() const;
 
     /**
-     * @brief Check if this @c XmlNode is of the named element in the
-     * given namespace.
+     * @brief Check if this @c XmlNode is an element node in the given
+     * namespace with the specified local name.
      *
-     * Checks whether this @c XmlNode has the argument element name in
-     * the given namespace.
-     * Returns @ true if so, and @c false otherwise.
+     * Checks whether this @c XmlNode is an element type node in the
+	 * given namespace with the specified local name.
+     * Returns @c true if so, and @c false otherwise.
      *
-     * @param elementNamespace The @c char namespace in which the element
-     * name is to be defined.
-     * @param elementName The @c char element name to check for.
+     * @param ns The @c char namespace in which the element
+     * node is to be defined.
+     * @param name The @c char element name to check for.
      *
-     * @return @c true if this @c XmlNode is of the element
-     * specified by the @p elementName in the namespace @elementNamespace
+     * @return @c true if this @c XmlNode is an element node in the
+	 * given namespace @p ns with the given local name @p name;
      * and @c false otherwise.
      */
-    bool isElement(const char *elementNamespace, const char *elementName);
+    bool isElement(const char *ns, const char *name);
 
     /**
-     * @brief Check if this @c XmlNode is of the named element in the
-     * CellML 2.0 namespace.
+     * @brief Check if this @c XmlNode is an element node in the
+     * CellML 2.0 namespace with the given local name.
      *
-     * Checks whether this @c XmlNode has the argument element name in
-     * the CellML 2.0 namespace.
-     * Returns @ true if so, and @c false otherwise.
+     * Checks whether this @c XmlNode is an element node in
+     * the CellML 2.0 namespace with the specified local name.
+     * Returns @p true if so, and @c false otherwise.
      *
-     * @param elementName The @c char element name to check for.
+     * @param name The @c char element name to check for.
      *
-     * @return @c true if this @c XmlNode is of the element
-     * specified by the @p elementName in the CellML 2.0 namespace and
+     * @return @c true if this @c XmlNode is an element node in the
+     * CellML 2.0 namespace with the given local name @p name; and
      * @c false otherwise.
      */
-    bool isCellmlElement(const char *elementName);
+    bool isCellmlElement(const char *name);
 
     /**
      * @brief Check if this @c XmlNode is a text node.

--- a/src/xmlnode.h
+++ b/src/xmlnode.h
@@ -61,38 +61,38 @@ public:
     std::string getNamespace() const;
 
     /**
-     * @brief Check if this @c XmlNode is of the named element type in the
+     * @brief Check if this @c XmlNode is of the named element in the
      * given namespace.
      *
-     * Checks whether this @c XmlNode has the argument element type name in
+     * Checks whether this @c XmlNode has the argument element name in
      * the given namespace.
      * Returns @ true if so, and @c false otherwise.
      *
      * @param elementNamespace The @c char namespace in which the element
-     * type name is to be defined.
-     * @param elementName The @c char element type name to check for.
+     * name is to be defined.
+     * @param elementName The @c char element name to check for.
      *
-     * @return @c true if this @c XmlNode is of the element type
+     * @return @c true if this @c XmlNode is of the element
      * specified by the @p elementName in the namespace @elementNamespace
      * and @c false otherwise.
      */
-    bool isType(const char *elementNamespace, const char *elementName);
+    bool isElement(const char *elementNamespace, const char *elementName);
 
     /**
-     * @brief Check if this @c XmlNode is of the named element type in the
+     * @brief Check if this @c XmlNode is of the named element in the
      * CellML 2.0 namespace.
      *
-     * Checks whether this @c XmlNode has the argument element type name in
+     * Checks whether this @c XmlNode has the argument element name in
      * the CellML 2.0 namespace.
      * Returns @ true if so, and @c false otherwise.
      *
-     * @param elementName The @c char element type name to check for.
+     * @param elementName The @c char element name to check for.
      *
-     * @return @c true if this @c XmlNode is of the element type
+     * @return @c true if this @c XmlNode is of the element
      * specified by the @p elementName in the CellML 2.0 namespace and
      * @c false otherwise.
      */
-    bool isType(const char *elementName);
+    bool isCellmlElement(const char *elementName);
 
     /**
      * @brief Check if this @c XmlNode is a text node.
@@ -116,13 +116,13 @@ public:
     bool isCommentNode();
 
     /**
-     * @brief Get the type name of the XML element.
+     * @brief Get the name of the XML element.
      *
-     * Get the type name of the XML element.
+     * Get the name of the XML element.
      *
-     * @return A @c std::string representation of the XML type name.
+     * @return A @c std::string representation of the XML name.
      */
-    std::string getType() const;
+    std::string getName() const;
 
     /**
      * @brief Check if this @c XmlNode has the specified attribute.

--- a/src/xmlnode.h
+++ b/src/xmlnode.h
@@ -65,7 +65,7 @@ public:
      * namespace with the specified local name.
      *
      * Checks whether this @c XmlNode is an element type node in the
-	 * given namespace with the specified local name.
+     * given namespace with the specified local name.
      * Returns @c true if so, and @c false otherwise.
      *
      * @param name The @c char element name to check for.
@@ -73,7 +73,7 @@ public:
      * node is to be defined.
      *
      * @return @c true if this @c XmlNode is an element node in the
-	 * given namespace @p ns with the given local name @p name;
+     * given namespace @p ns with the given local name @p name;
      * and @c false otherwise.
      */
     bool isElement(const char *name, const char *ns);


### PR DESCRIPTION
Attempting to clarify the XmlNode and XmlAttribute type methods as the existing API got a bit confusing with the addition of namespace aware methods. See cellml/libcellml#274.