### PR TITLE
Issue298 Validator false positive for component imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ CMakeLists.txt.user
 
 # OS X hidden system files
 .DS_Store
-
-# VS Code system files
-.vscode/

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -293,7 +293,7 @@ void Validator::validateModel(const ModelPtr &model)
             std::string componentName = component->name();
             if (!componentName.empty()) {
                 if (component->isImport()) {
-                    // Check for a component_ref; assumes imported if the import source is not null
+                    // Check for a component_ref; assumes imported if the import source is not null.
                     std::string componentRef = component->importReference();
                     std::string importSource = component->importSource()->url();
 
@@ -311,8 +311,8 @@ void Validator::validateModel(const ModelPtr &model)
                         err->setRule(SpecificationRule::IMPORT_HREF);
                         addError(err);
                     } else {
-                        xmlURIPtr URIPtr = xmlParseURI(importSource.c_str());
-                        if (URIPtr == nullptr) {
+                        xmlURIPtr uri = xmlParseURI(importSource.c_str());
+                        if (uri == nullptr) {
                             ErrorPtr err = std::make_shared<Error>();
                             err->setDescription("Import of component '" + componentName + "' has an invalid URI in the href attribute.");
                             err->setImportSource(component->importSource());
@@ -320,7 +320,7 @@ void Validator::validateModel(const ModelPtr &model)
                             addError(err);
 
                         } else {
-                            xmlFreeURI(URIPtr);
+                            xmlFreeURI(uri);
                         }
                     }
                     // Push back the unique sources and refs.

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -314,7 +314,7 @@ void Validator::validateModel(const ModelPtr &model)
                         xmlURIPtr URIPtr = xmlParseURI(importSource.c_str());
                         if (URIPtr == nullptr) {
                             ErrorPtr err = std::make_shared<Error>();
-                            err->setDescription("Import of component '" + componentName + "' has an invalid URI in the href attribute, '" + importSource + "'. ");
+                            err->setDescription("Import of component '" + componentName + "' has an invalid URI in the href attribute.");
                             err->setImportSource(component->importSource());
                             err->setRule(SpecificationRule::IMPORT_HREF);
                             addError(err);

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -28,6 +28,8 @@ limitations under the License.
 #include "libcellml/variable.h"
 #include "libcellml/when.h"
 
+#include <libxml/uri.h>
+
 #include <map>
 #include <regex>
 #include <sstream>
@@ -291,38 +293,34 @@ void Validator::validateModel(const ModelPtr &model)
             std::string componentName = component->name();
             if (!componentName.empty()) {
                 if (component->isImport()) {
-                    // Check for a component_ref.
+                    // Check for a component_ref; assumes imported if the import source is not null
                     std::string componentRef = component->importReference();
                     std::string importSource = component->importSource()->url();
-                    bool foundImportError = false;
+
                     if (!mPimpl->isCellmlIdentifier(componentRef)) {
                         ErrorPtr err = std::make_shared<Error>();
                         err->setDescription("Imported component '" + componentName + "' does not have a valid component_ref attribute.");
                         err->setComponent(component);
                         err->setRule(SpecificationRule::IMPORT_COMPONENT_REF);
                         addError(err);
-                        foundImportError = true;
                     }
-                    // Check for a xlink:href.
-                    // TODO: check this id against the XLink spec (see CellML Spec 5.1.1).
                     if (importSource.empty()) {
                         ErrorPtr err = std::make_shared<Error>();
                         err->setDescription("Import of component '" + componentName + "' does not have a valid locator xlink:href attribute.");
                         err->setImportSource(component->importSource());
                         err->setRule(SpecificationRule::IMPORT_HREF);
                         addError(err);
-                        foundImportError = true;
-                    }
-                    // Check if we already have another import from the same source with the same component_ref.
-                    // (This looks for matching entries at the same position in the source and ref vectors).
-                    if (!componentImportSources.empty() && (!foundImportError)) {
-                        if ((std::find(componentImportSources.begin(), componentImportSources.end(), importSource) - componentImportSources.begin())
-                            == (std::find(componentRefs.begin(), componentRefs.end(), componentRef) - componentRefs.begin())) {
+                    } else {
+                        xmlURIPtr URIPtr = xmlParseURI(importSource.c_str());
+                        if (URIPtr == nullptr) {
                             ErrorPtr err = std::make_shared<Error>();
-                            err->setDescription("Model '" + model->name() + "' contains multiple imported components from '" + importSource + "' with the same component_ref attribute '" + componentRef + "'.");
-                            err->setModel(model);
-                            err->setRule(SpecificationRule::IMPORT_COMPONENT_REF);
+                            err->setDescription("Import of component '" + componentName + "' has an invalid URI in the href attribute, '" + importSource + "'. ");
+                            err->setImportSource(component->importSource());
+                            err->setRule(SpecificationRule::IMPORT_HREF);
                             addError(err);
+
+                        } else {
+                            xmlFreeURI(URIPtr);
                         }
                     }
                     // Push back the unique sources and refs.

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -84,7 +84,7 @@ struct Validator::ValidatorImpl
      * Checks if the provided @p name is a valid CellML identifier according
      * to the CellML 2.0 specification. This requires a non-zero length Unicode
      * character sequence containing basic Latin alphanumeric characters or
-     * underscores that does not start with a number.
+     * underscores that does not begin with a number.
      *
      * @param name The @c std::string name to check the validity of.
      *

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -28,13 +28,13 @@ limitations under the License.
 #include "libcellml/variable.h"
 #include "libcellml/when.h"
 
-#include <libxml/uri.h>
-
 #include <map>
 #include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include <libxml/uri.h>
 
 namespace libcellml {
 

--- a/tests/validator/validator.cpp
+++ b/tests/validator/validator.cpp
@@ -394,7 +394,7 @@ TEST(Validator, importComponents)
 
     // Invalid: component_ref url is not valid html
     libcellml::ImportSourcePtr imp9 = std::make_shared<libcellml::ImportSource>();
-    imp9->setUrl("not @ valid url"); 
+    imp9->setUrl("not @ valid url");
     libcellml::ComponentPtr importedComponent9 = std::make_shared<libcellml::Component>();
     importedComponent9->setName("a_bad_imported_component");
     importedComponent9->setSourceComponent(imp9, "component_in_some_model");

--- a/tests/validator/validator.cpp
+++ b/tests/validator/validator.cpp
@@ -344,7 +344,7 @@ TEST(Validator, importComponents)
     v.validateModel(m);
     EXPECT_EQ(size_t(0), v.errorCount());
 
-    // Invalid component import - missing refs
+    // Invalid component import - missing ref to source component
     libcellml::ImportSourcePtr imp3 = std::make_shared<libcellml::ImportSource>();
     libcellml::ComponentPtr importedComponent3 = std::make_shared<libcellml::Component>();
     importedComponent3->setName("invalid_imported_component_in_this_model");
@@ -353,7 +353,7 @@ TEST(Validator, importComponents)
     v.validateModel(m);
     EXPECT_EQ(size_t(3), v.errorCount());
 
-    // Invalid component import - duplicate refs
+    // Valid component import - two components imported from the same place is allowed
     libcellml::ImportSourcePtr imp4 = std::make_shared<libcellml::ImportSource>();
     imp4->setUrl("some-other-model.xml");
     libcellml::ComponentPtr importedComponent4 = std::make_shared<libcellml::Component>();
@@ -363,6 +363,7 @@ TEST(Validator, importComponents)
     v.validateModel(m);
     EXPECT_EQ(size_t(3), v.errorCount());
 
+    // Invalid - name missing from component
     libcellml::ImportSourcePtr imp5 = std::make_shared<libcellml::ImportSource>();
     imp5->setUrl("some-other-different-model.xml");
     libcellml::ComponentPtr importedComponent5 = std::make_shared<libcellml::Component>();
@@ -371,7 +372,7 @@ TEST(Validator, importComponents)
     v.validateModel(m);
     EXPECT_EQ(size_t(5), v.errorCount());
 
-    // Invalid: duplicating component_ref and source
+    // Valid - two components from the same source is allowed
     libcellml::ImportSourcePtr imp7 = std::make_shared<libcellml::ImportSource>();
     imp7->setUrl("yet-another-other-model.xml");
     libcellml::ComponentPtr importedComponent7 = std::make_shared<libcellml::Component>();
@@ -381,7 +382,7 @@ TEST(Validator, importComponents)
     v.validateModel(m);
     EXPECT_EQ(size_t(5), v.errorCount());
 
-    // Valid: duplicate component_ref from a different source
+    // Valid - duplicate component_ref from a different source
     libcellml::ImportSourcePtr imp8 = std::make_shared<libcellml::ImportSource>();
     imp8->setUrl("yet-another-other-model.xml"); // source used before
     libcellml::ComponentPtr importedComponent8 = std::make_shared<libcellml::Component>();
@@ -393,7 +394,7 @@ TEST(Validator, importComponents)
 
     // Invalid: component_ref is not valid html
     libcellml::ImportSourcePtr imp9 = std::make_shared<libcellml::ImportSource>();
-    imp9->setUrl("not @ valid url"); // source used before
+    imp9->setUrl("not @ valid url"); // source used before but is not valid
     libcellml::ComponentPtr importedComponent9 = std::make_shared<libcellml::Component>();
     importedComponent9->setName("a_bad_imported_component");
     importedComponent9->setSourceComponent(imp9, "component_in_some_model");

--- a/tests/validator/validator.cpp
+++ b/tests/validator/validator.cpp
@@ -312,13 +312,14 @@ TEST(Validator, importUnits)
 
 TEST(Validator, importComponents)
 {
-    const std::vector<std::string> expectedErrors = {
+    std::vector<std::string> expectedErrors = {
         "CellML identifiers must contain one or more basic Latin alphabetic characters.",
         "Imported component 'invalid_imported_component_in_this_model' does not have a valid component_ref attribute.",
         "Import of component 'invalid_imported_component_in_this_model' does not have a valid locator xlink:href attribute.",
-        "Model 'model_name' contains multiple imported components from 'some-other-model.xml' with the same component_ref attribute 'component_in_that_model'.",
         "CellML identifiers must contain one or more basic Latin alphabetic characters.",
-        "Imported component does not have a valid name attribute."};
+        "Imported component does not have a valid name attribute.",
+        "Import of component 'a_bad_imported_component' has an invalid URI in the href attribute, 'not @ valid url'. ",
+    };
 
     libcellml::Validator v;
     libcellml::ModelPtr m = std::make_shared<libcellml::Model>();
@@ -334,7 +335,17 @@ TEST(Validator, importComponents)
     v.validateModel(m);
     EXPECT_EQ(size_t(0), v.errorCount());
 
-    // Invalid component import- missing refs
+    // Another valid component import
+    libcellml::ImportSourcePtr imp5 = std::make_shared<libcellml::ImportSource>();
+    imp5->setUrl("yet-another-other-model.xml");
+    libcellml::ComponentPtr importedComponent5 = std::make_shared<libcellml::Component>();
+    importedComponent5->setName("another_valid_imported_component_in_this_model");
+    importedComponent5->setSourceComponent(imp5, "new_shiny_component_ref");
+    m->addComponent(importedComponent5);
+    v.validateModel(m);
+    EXPECT_EQ(size_t(0), v.errorCount());
+
+    // Invalid component import - missing refs
     libcellml::ImportSourcePtr imp2 = std::make_shared<libcellml::ImportSource>();
     libcellml::ComponentPtr importedComponent2 = std::make_shared<libcellml::Component>();
     importedComponent2->setName("invalid_imported_component_in_this_model");
@@ -343,7 +354,7 @@ TEST(Validator, importComponents)
     v.validateModel(m);
     EXPECT_EQ(size_t(3), v.errorCount());
 
-    // Invalid component import - duplicate refs
+    // Invalid component import - duplicate refs  TODO but is this allowed after all ?? #280, #298
     libcellml::ImportSourcePtr imp3 = std::make_shared<libcellml::ImportSource>();
     imp3->setUrl("some-other-model.xml");
     libcellml::ComponentPtr importedComponent3 = std::make_shared<libcellml::Component>();
@@ -351,14 +362,43 @@ TEST(Validator, importComponents)
     importedComponent3->setSourceComponent(imp3, "component_in_that_model");
     m->addComponent(importedComponent3);
     v.validateModel(m);
-    EXPECT_EQ(size_t(4), v.errorCount());
+    EXPECT_EQ(size_t(3), v.errorCount());
 
-    // Invalid component import - unnamed component
     libcellml::ImportSourcePtr imp4 = std::make_shared<libcellml::ImportSource>();
     imp4->setUrl("some-other-different-model.xml");
     libcellml::ComponentPtr importedComponent4 = std::make_shared<libcellml::Component>();
     importedComponent4->setSourceComponent(imp4, "component_in_that_model");
     m->addComponent(importedComponent4);
+    v.validateModel(m);
+    EXPECT_EQ(size_t(5), v.errorCount());
+
+    // Invalid: duplicating component_ref and source TODO but is this allowed after all ?? #280, #298
+    libcellml::ImportSourcePtr imp6 = std::make_shared<libcellml::ImportSource>();
+    imp6->setUrl("yet-another-other-model.xml");
+    libcellml::ComponentPtr importedComponent6 = std::make_shared<libcellml::Component>();
+    importedComponent6->setName("another_duplicate_imported_component");
+    importedComponent6->setSourceComponent(imp6, "new_shiny_component_ref");
+    m->addComponent(importedComponent6);
+    v.validateModel(m);
+    EXPECT_EQ(size_t(5), v.errorCount());
+
+    // Valid: duplicate component_ref from a different source
+    libcellml::ImportSourcePtr imp7 = std::make_shared<libcellml::ImportSource>();
+    imp7->setUrl("yet-another-other-model.xml"); // source used before
+    libcellml::ComponentPtr importedComponent7 = std::make_shared<libcellml::Component>();
+    importedComponent7->setName("a_good_imported_component");
+    importedComponent7->setSourceComponent(imp7, "component_in_that_model");
+    m->addComponent(importedComponent7);
+    v.validateModel(m);
+    EXPECT_EQ(size_t(5), v.errorCount());
+
+    // Invalid: component_ref is not valid html
+    libcellml::ImportSourcePtr imp8 = std::make_shared<libcellml::ImportSource>();
+    imp8->setUrl("not @ valid url"); // source used before
+    libcellml::ComponentPtr importedComponent8 = std::make_shared<libcellml::Component>();
+    importedComponent8->setName("a_bad_imported_component");
+    importedComponent8->setSourceComponent(imp8, "component_in_some_model");
+    m->addComponent(importedComponent8);
     v.validateModel(m);
     EXPECT_EQ(size_t(6), v.errorCount());
 

--- a/tests/validator/validator.cpp
+++ b/tests/validator/validator.cpp
@@ -318,8 +318,7 @@ TEST(Validator, importComponents)
         "Import of component 'invalid_imported_component_in_this_model' does not have a valid locator xlink:href attribute.",
         "CellML identifiers must contain one or more basic Latin alphabetic characters.",
         "Imported component does not have a valid name attribute.",
-        "Import of component 'a_bad_imported_component' has an invalid URI in the href attribute, 'not @ valid url'. ",
-    };
+        "Import of component 'a_bad_imported_component' has an invalid URI in the href attribute."};
 
     libcellml::Validator v;
     libcellml::ModelPtr m = std::make_shared<libcellml::Model>();

--- a/tests/validator/validator.cpp
+++ b/tests/validator/validator.cpp
@@ -392,9 +392,9 @@ TEST(Validator, importComponents)
     v.validateModel(m);
     EXPECT_EQ(size_t(5), v.errorCount());
 
-    // Invalid: component_ref is not valid html
+    // Invalid: component_ref url is not valid html
     libcellml::ImportSourcePtr imp9 = std::make_shared<libcellml::ImportSource>();
-    imp9->setUrl("not @ valid url"); // source used before but is not valid
+    imp9->setUrl("not @ valid url"); 
     libcellml::ComponentPtr importedComponent9 = std::make_shared<libcellml::Component>();
     importedComponent9->setName("a_bad_imported_component");
     importedComponent9->setSourceComponent(imp9, "component_in_some_model");

--- a/tests/validator/validator.cpp
+++ b/tests/validator/validator.cpp
@@ -335,69 +335,69 @@ TEST(Validator, importComponents)
     EXPECT_EQ(size_t(0), v.errorCount());
 
     // Another valid component import
-    libcellml::ImportSourcePtr imp5 = std::make_shared<libcellml::ImportSource>();
-    imp5->setUrl("yet-another-other-model.xml");
-    libcellml::ComponentPtr importedComponent5 = std::make_shared<libcellml::Component>();
-    importedComponent5->setName("another_valid_imported_component_in_this_model");
-    importedComponent5->setSourceComponent(imp5, "new_shiny_component_ref");
-    m->addComponent(importedComponent5);
+    libcellml::ImportSourcePtr imp2 = std::make_shared<libcellml::ImportSource>();
+    imp2->setUrl("yet-another-other-model.xml");
+    libcellml::ComponentPtr importedComponent2 = std::make_shared<libcellml::Component>();
+    importedComponent2->setName("another_valid_imported_component_in_this_model");
+    importedComponent2->setSourceComponent(imp2, "new_shiny_component_ref");
+    m->addComponent(importedComponent2);
     v.validateModel(m);
     EXPECT_EQ(size_t(0), v.errorCount());
 
     // Invalid component import - missing refs
-    libcellml::ImportSourcePtr imp2 = std::make_shared<libcellml::ImportSource>();
-    libcellml::ComponentPtr importedComponent2 = std::make_shared<libcellml::Component>();
-    importedComponent2->setName("invalid_imported_component_in_this_model");
-    importedComponent2->setSourceComponent(imp2, "");
-    m->addComponent(importedComponent2);
-    v.validateModel(m);
-    EXPECT_EQ(size_t(3), v.errorCount());
-
-    // Invalid component import - duplicate refs  TODO but is this allowed after all ?? #280, #298
     libcellml::ImportSourcePtr imp3 = std::make_shared<libcellml::ImportSource>();
-    imp3->setUrl("some-other-model.xml");
     libcellml::ComponentPtr importedComponent3 = std::make_shared<libcellml::Component>();
-    importedComponent3->setName("duplicate_imported_component_in_this_model");
-    importedComponent3->setSourceComponent(imp3, "component_in_that_model");
+    importedComponent3->setName("invalid_imported_component_in_this_model");
+    importedComponent3->setSourceComponent(imp3, "");
     m->addComponent(importedComponent3);
     v.validateModel(m);
     EXPECT_EQ(size_t(3), v.errorCount());
 
+    // Invalid component import - duplicate refs
     libcellml::ImportSourcePtr imp4 = std::make_shared<libcellml::ImportSource>();
-    imp4->setUrl("some-other-different-model.xml");
+    imp4->setUrl("some-other-model.xml");
     libcellml::ComponentPtr importedComponent4 = std::make_shared<libcellml::Component>();
+    importedComponent4->setName("duplicate_imported_component_in_this_model");
     importedComponent4->setSourceComponent(imp4, "component_in_that_model");
     m->addComponent(importedComponent4);
     v.validateModel(m);
-    EXPECT_EQ(size_t(5), v.errorCount());
+    EXPECT_EQ(size_t(3), v.errorCount());
 
-    // Invalid: duplicating component_ref and source TODO but is this allowed after all ?? #280, #298
-    libcellml::ImportSourcePtr imp6 = std::make_shared<libcellml::ImportSource>();
-    imp6->setUrl("yet-another-other-model.xml");
-    libcellml::ComponentPtr importedComponent6 = std::make_shared<libcellml::Component>();
-    importedComponent6->setName("another_duplicate_imported_component");
-    importedComponent6->setSourceComponent(imp6, "new_shiny_component_ref");
-    m->addComponent(importedComponent6);
+    libcellml::ImportSourcePtr imp5 = std::make_shared<libcellml::ImportSource>();
+    imp5->setUrl("some-other-different-model.xml");
+    libcellml::ComponentPtr importedComponent5 = std::make_shared<libcellml::Component>();
+    importedComponent5->setSourceComponent(imp5, "component_in_that_model");
+    m->addComponent(importedComponent5);
     v.validateModel(m);
     EXPECT_EQ(size_t(5), v.errorCount());
 
-    // Valid: duplicate component_ref from a different source
+    // Invalid: duplicating component_ref and source
     libcellml::ImportSourcePtr imp7 = std::make_shared<libcellml::ImportSource>();
-    imp7->setUrl("yet-another-other-model.xml"); // source used before
+    imp7->setUrl("yet-another-other-model.xml");
     libcellml::ComponentPtr importedComponent7 = std::make_shared<libcellml::Component>();
-    importedComponent7->setName("a_good_imported_component");
-    importedComponent7->setSourceComponent(imp7, "component_in_that_model");
+    importedComponent7->setName("another_duplicate_imported_component");
+    importedComponent7->setSourceComponent(imp7, "new_shiny_component_ref");
     m->addComponent(importedComponent7);
     v.validateModel(m);
     EXPECT_EQ(size_t(5), v.errorCount());
 
-    // Invalid: component_ref is not valid html
+    // Valid: duplicate component_ref from a different source
     libcellml::ImportSourcePtr imp8 = std::make_shared<libcellml::ImportSource>();
-    imp8->setUrl("not @ valid url"); // source used before
+    imp8->setUrl("yet-another-other-model.xml"); // source used before
     libcellml::ComponentPtr importedComponent8 = std::make_shared<libcellml::Component>();
-    importedComponent8->setName("a_bad_imported_component");
-    importedComponent8->setSourceComponent(imp8, "component_in_some_model");
+    importedComponent8->setName("a_good_imported_component");
+    importedComponent8->setSourceComponent(imp8, "component_in_that_model");
     m->addComponent(importedComponent8);
+    v.validateModel(m);
+    EXPECT_EQ(size_t(5), v.errorCount());
+
+    // Invalid: component_ref is not valid html
+    libcellml::ImportSourcePtr imp9 = std::make_shared<libcellml::ImportSource>();
+    imp9->setUrl("not @ valid url"); // source used before
+    libcellml::ComponentPtr importedComponent9 = std::make_shared<libcellml::Component>();
+    importedComponent9->setName("a_bad_imported_component");
+    importedComponent9->setSourceComponent(imp9, "component_in_some_model");
+    m->addComponent(importedComponent9);
     v.validateModel(m);
     EXPECT_EQ(size_t(6), v.errorCount());
 

--- a/tests/validator/validator.cpp
+++ b/tests/validator/validator.cpp
@@ -312,7 +312,7 @@ TEST(Validator, importUnits)
 
 TEST(Validator, importComponents)
 {
-    std::vector<std::string> expectedErrors = {
+    const std::vector<std::string> expectedErrors = {
         "CellML identifiers must contain one or more basic Latin alphabetic characters.",
         "Imported component 'invalid_imported_component_in_this_model' does not have a valid component_ref attribute.",
         "Import of component 'invalid_imported_component_in_this_model' does not have a valid locator xlink:href attribute.",


### PR DESCRIPTION
Addresses bug discussed in #298 

False positives returned from the validateModel when checking components.
The bug is fixed and the test is updated.