### PR TITLE
Test API headers can be included standalone. 

### DIFF
--- a/src/api/libcellml/generatorprofile.h
+++ b/src/api/libcellml/generatorprofile.h
@@ -16,6 +16,8 @@ limitations under the License.
 
 #pragma once
 
+#include <string>
+
 #include "libcellml/exportdefinitions.h"
 
 namespace libcellml {

--- a/src/generatorprofile.cpp
+++ b/src/generatorprofile.cpp
@@ -18,12 +18,12 @@ limitations under the License.
 #    define _USE_MATH_DEFINES
 #endif
 
-#include "utilities.h"
-
 #include "libcellml/generatorprofile.h"
 
 #include <cmath>
 #include <string>
+
+#include "utilities.h"
 
 namespace libcellml {
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,13 @@ foreach(TEST ${LIBCELLML_TESTS})
   unset(CURRENT_CATEGORY)
 endforeach()
 
+# Generate tests for header files.
+# Generated tests will be in the build directory based off the list of API header files.
+
+# configure a template header test and then from the template generate the actual test for the header
+# then include the generated test
+include(api_headers/tests.cmake)
+
 add_subdirectory(bindings)
 
 if(LIBCELLML_COVERAGE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,10 +91,6 @@ foreach(TEST ${LIBCELLML_TESTS})
 endforeach()
 
 # Generate tests for header files.
-# Generated tests will be in the build directory based off the list of API header files.
-
-# configure a template header test and then from the template generate the actual test for the header
-# then include the generated test
 include(api_headers/tests.cmake)
 
 add_subdirectory(bindings)

--- a/tests/api_headers/api_header_test.in.cmake
+++ b/tests/api_headers/api_header_test.in.cmake
@@ -9,4 +9,15 @@ set_target_properties(${CURRENT_TEST} PROPERTIES
 
 add_test(NAME api_header_inclusion_${CURRENT_TEST} COMMAND ${CURRENT_TEST})
 
+if(MSVC)
+  if(HAVE_LIBXML2_CONFIG)
+	set_tests_properties(api_header_inclusion_${CURRENT_TEST}
+	PROPERTIES ENVIRONMENT "PATH=$<TARGET_FILE_DIR:cellml>\;$<TARGET_FILE_DIR:gtest_main>\;$<TARGET_FILE_DIR:xml2>")
+  else()
+	# The libxml2 dll must be on the path otherwise the tests will not be able to run.
+	set_tests_properties(api_header_inclusion_${CURRENT_TEST}
+	PROPERTIES ENVIRONMENT "PATH=$<TARGET_FILE_DIR:cellml>\;$<TARGET_FILE_DIR:gtest_main>")
+  endif()
+endif()
+
 list(APPEND TEST_LIST ${CURRENT_TEST})

--- a/tests/api_headers/api_header_test.in.cmake
+++ b/tests/api_headers/api_header_test.in.cmake
@@ -1,0 +1,12 @@
+
+add_executable(${CURRENT_TEST} ${TEST_SRC})
+target_link_libraries(${CURRENT_TEST} cellml gtest_main)
+
+set_target_properties(${CURRENT_TEST} PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON
+  FOLDER tests)
+
+add_test(NAME api_header_inclusion_${CURRENT_TEST} COMMAND ${CURRENT_TEST})
+
+list(APPEND TEST_LIST ${CURRENT_TEST})

--- a/tests/api_headers/api_header_test.in.cpp
+++ b/tests/api_headers/api_header_test.in.cpp
@@ -1,0 +1,29 @@
+
+/*
+Copyright libCellML Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <libcellml/@TEST_HEADER@>
+
+#include "gtest/gtest.h"
+
+/*
+ * Generated test to ensure header files can be included independently.
+ */
+TEST(APIHeader, @TEST_HEADER_NAME@)
+{
+    EXPECT_TRUE(size_t(4) == size_t(4));
+}
+

--- a/tests/api_headers/tests.cmake
+++ b/tests/api_headers/tests.cmake
@@ -1,0 +1,13 @@
+foreach(_API_HEADER_FILE ${API_HEADER_FILES})
+  get_filename_component(TEST_HEADER_NAME ${_API_HEADER_FILE} NAME_WE)
+  get_filename_component(TEST_HEADER ${_API_HEADER_FILE} NAME)
+  set(CURRENT_TEST test_api_headers_${TEST_HEADER_NAME})
+
+  set(TEST_SRC ${CMAKE_CURRENT_BINARY_DIR}/api_header_${TEST_HEADER_NAME}.cpp)
+  set(TEST_CMAKE_FILE ${CMAKE_CURRENT_BINARY_DIR}/api_header_${TEST_HEADER_NAME}.cmake)
+  configure_file(api_headers/api_header_test.in.cpp ${TEST_SRC})
+  configure_file(api_headers/api_header_test.in.cmake ${TEST_CMAKE_FILE})
+  include(${TEST_CMAKE_FILE})
+endforeach()
+
+message(STATUS "TEST_LIST: ${TEST_LIST}")

--- a/tests/api_headers/tests.cmake
+++ b/tests/api_headers/tests.cmake
@@ -3,11 +3,9 @@ foreach(_API_HEADER_FILE ${API_HEADER_FILES})
   get_filename_component(TEST_HEADER ${_API_HEADER_FILE} NAME)
   set(CURRENT_TEST test_api_headers_${TEST_HEADER_NAME})
 
-  set(TEST_SRC ${CMAKE_CURRENT_BINARY_DIR}/api_header_${TEST_HEADER_NAME}.cpp)
-  set(TEST_CMAKE_FILE ${CMAKE_CURRENT_BINARY_DIR}/api_header_${TEST_HEADER_NAME}.cmake)
+  set(TEST_SRC ${CMAKE_CURRENT_BINARY_DIR}/api_headers/api_header_${TEST_HEADER_NAME}.cpp)
+  set(TEST_CMAKE_FILE ${CMAKE_CURRENT_BINARY_DIR}/api_headers/api_header_${TEST_HEADER_NAME}.cmake)
   configure_file(api_headers/api_header_test.in.cpp ${TEST_SRC})
   configure_file(api_headers/api_header_test.in.cmake ${TEST_CMAKE_FILE})
   include(${TEST_CMAKE_FILE})
 endforeach()
-
-message(STATUS "TEST_LIST: ${TEST_LIST}")


### PR DESCRIPTION
This pull request adds generated tests that check that each API header can be included on its own.

Addresses #178.