### PR TITLE
Maths validation bring in cellml xml namespace

### DIFF
--- a/src/api/libcellml/validator.h
+++ b/src/api/libcellml/validator.h
@@ -17,9 +17,7 @@ limitations under the License.
 #pragma once
 
 #include "libcellml/logger.h"
-#include "libcellml/model.h"
 #include "libcellml/types.h"
-#include "libcellml/units.h"
 
 #include <string>
 #include <vector>

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -30,6 +30,8 @@ limitations under the License.
 #include <cmath>
 #include <stdexcept>
 
+#include <iostream>
+
 #include <libxml/uri.h>
 
 namespace libcellml {
@@ -781,9 +783,22 @@ void Validator::ValidatorImpl::validateWhen(const WhenPtr &when, const ResetPtr 
 
 void Validator::ValidatorImpl::validateMath(const std::string &input, const ComponentPtr &component)
 {
+    const std::string cellml2NamespaceString = std::string(" xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\"");
+
     XmlDocPtr doc = std::make_shared<XmlDoc>();
     // Parse as XML first.
-    doc->parse(input);
+    std::string modifiedInput = input;
+//    if (input.find(cellml2NamespaceString) == std::string::npos) {
+//        std::cout << "no cellml namespace" << std::endl;
+//        const std::string keyText = "MathML\"";
+//        size_t foundAt = input.find(keyText);
+//        if (foundAt != std::string::npos) {
+//            std::cout << "adjusting" << std::endl;
+//            modifiedInput.insert(foundAt + std::string(keyText).size(), cellml2NamespaceString);
+//        }
+//        std::cout << modifiedInput;
+//    }
+    doc->parse(modifiedInput);
     // Copy any XML parsing errors into the common validator error handler.
     if (doc->xmlErrorCount() > 0) {
         for (size_t i = 0; i < doc->xmlErrorCount(); ++i) {
@@ -840,7 +855,6 @@ void Validator::ValidatorImpl::validateMath(const std::string &input, const Comp
     // Get the MathML string (with cellml:units attributes already removed) and remove the CellML namespace.
     // While the removeSubstring() approach for removing the cellml namespace before validating with the MathML DTD
     // is not ideal, libxml does not appear to have a better way to remove a namespace declaration from the tree.
-    std::string cellml2NamespaceString = std::string(" xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\"");
     std::string cleanMathml = mathNode->convertToString();
     removeSubstring(cleanMathml, cellml2NamespaceString);
 

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -837,21 +837,19 @@ void Validator::ValidatorImpl::validateWhen(const WhenPtr &when, const ResetPtr 
 
 void Validator::ValidatorImpl::validateMath(const std::string &input, const ComponentPtr &component)
 {
-    const std::string cellml2NamespaceString = std::string(" xmlns:cellml=\"http://www.cellml.org/cellml/2.0#\"");
+    std::string modifiedInput = input;
+
+    // It may be that we need to copy over the cellml namespace from the enclosing document.
+    auto cellMLNamespaceText = " xmlns:cellml=\"" + std::string(CELLML_2_0_NS);
+    if (input.find("cellml:units") != std::string::npos && input.find(cellMLNamespaceText) == std::string::npos) {
+        auto foundIndex = input.find(MATHML_NS);
+        if (foundIndex) {
+            modifiedInput.replace(foundIndex, std::string(MATHML_NS).length(), std::string(MATHML_NS) + "\"" + cellMLNamespaceText);
+        }
+    }
 
     XmlDocPtr doc = std::make_shared<XmlDoc>();
     // Parse as XML first.
-    std::string modifiedInput = input;
-//    if (input.find(cellml2NamespaceString) == std::string::npos) {
-//        std::cout << "no cellml namespace" << std::endl;
-//        const std::string keyText = "MathML\"";
-//        size_t foundAt = input.find(keyText);
-//        if (foundAt != std::string::npos) {
-//            std::cout << "adjusting" << std::endl;
-//            modifiedInput.insert(foundAt + std::string(keyText).size(), cellml2NamespaceString);
-//        }
-//        std::cout << modifiedInput;
-//    }
     doc->parse(modifiedInput);
     // Copy any XML parsing errors into the common validator error handler.
     if (doc->xmlErrorCount() > 0) {

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -838,11 +838,11 @@ void Validator::ValidatorImpl::validateMath(const std::string &input, const Comp
     std::string modifiedInput = input;
 
     // It may be that we need to copy over the cellml namespace from the enclosing document.
-    auto cellMLNamespaceText = " xmlns:cellml=\"" + std::string(CELLML_2_0_NS);
-    if (input.find("cellml:units") != std::string::npos && input.find(cellMLNamespaceText) == std::string::npos) {
+    auto cellmlNamespaceText = " xmlns:cellml=\"" + std::string(CELLML_2_0_NS);
+    if (input.find("cellml:units") != std::string::npos && input.find(cellmlNamespaceText) == std::string::npos) {
         auto foundIndex = input.find(MATHML_NS);
         if (foundIndex != std::string::npos) {
-            modifiedInput.replace(foundIndex, std::string(MATHML_NS).length(), std::string(MATHML_NS) + "\"" + cellMLNamespaceText);
+            modifiedInput.replace(foundIndex, std::string(MATHML_NS).length(), std::string(MATHML_NS) + "\"" + cellmlNamespaceText);
         }
     }
 
@@ -906,7 +906,7 @@ void Validator::ValidatorImpl::validateMath(const std::string &input, const Comp
     // While the removeSubstring() approach for removing the cellml namespace before validating with the MathML DTD
     // is not ideal, libxml does not appear to have a better way to remove a namespace declaration from the tree.
     std::string cleanMathml = mathNode->convertToString();
-    removeSubstring(cleanMathml, cellMLNamespaceText + "\"");
+    removeSubstring(cleanMathml, cellmlNamespaceText + "\"");
 
     // Parse/validate the clean math string with the W3C MathML DTD.
     XmlDocPtr mathmlDoc = std::make_shared<XmlDoc>();

--- a/tests/math/math.cpp
+++ b/tests/math/math.cpp
@@ -20,8 +20,6 @@ limitations under the License.
 
 #include <libcellml>
 
-static const std::string EMPTY_MATH = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\"/>\n";
-
 TEST(Maths, setAndGetMath)
 {
     libcellml::Component c;

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -20,6 +20,8 @@ limitations under the License.
 
 #include "test_exportdefinitions.h"
 
+const std::string EMPTY_MATH = "<math xmlns=\"http://www.w3.org/1998/Math/MathML\"/>\n";
+
 std::string TEST_EXPORT resourcePath(const std::string &resourceRelativePath = "");
 
 std::string TEST_EXPORT fileContents(const std::string &fileName);


### PR DESCRIPTION
Using a text based method to bring in the cellml xml namespace (if required) into math sub documents on validation.

Addresses issue #175.