### PR TITLE
Expose Entity->parent() as Model or Component for Python

### DIFF
--- a/src/api/libcellml/entity.h
+++ b/src/api/libcellml/entity.h
@@ -111,6 +111,20 @@ public:
      */
     bool hasAncestor(const EntityPtr &entity) const;
 
+    /**
+     * @brief Return the parent pointer cast to a Model
+     * 
+     * @return The pointer to this entity's parent cast as a Model
+     * */
+    ModelPtr parentAsModel();
+
+    /**
+     * @brief Return the parent pointer cast to a Component
+     * 
+     * @return The pointer to this entity's parent cast as a Component
+     * */
+    ComponentPtr parentAsComponent();
+
 private:
     void swap(Entity &rhs); /**< Swap method required for C++ 11 move semantics. */
 

--- a/src/bindings/interface/entity.i
+++ b/src/bindings/interface/entity.i
@@ -31,6 +31,12 @@ unset).";
 %feature("docstring") libcellml::Entity::setParent
 "Set the parent of the entity to the given Model or Component.";
 
+%feature("docstring") libcellml::Entity::parentAsModel
+"Return the parent of the entity to the given entity cast as a ModelPtr.";
+
+%feature("docstring") libcellml::Entity::parentAsComponent
+"Return the parent of the entity to the given entity cast as a ComponentPtr.";
+
 %{
 #include "libcellml/entity.h"
 %}

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -119,4 +119,16 @@ bool Entity::hasAncestor(const EntityPtr &entity) const
     return hasAncestor;
 }
 
+ModelPtr Entity::parentAsModel()
+{
+    EntityPtr parent = mPimpl->mParent.lock();
+    return std::dynamic_pointer_cast<Model>(parent);
+}
+
+ComponentPtr Entity::parentAsComponent()
+{
+    EntityPtr parent = mPimpl->mParent.lock();
+    return std::dynamic_pointer_cast<Component>(parent);
+}
+
 } // namespace libcellml


### PR DESCRIPTION
Addresses #422 

... and yeah, I know there's no test, but that's because I can't figure out how to write one ... I just need to get the parent pointer in the correct typecast in python.  These changes do what I need, but not sure what others will think?