### PR TITLE
Add clone method.

### DIFF
--- a/src/api/libcellml/component.h
+++ b/src/api/libcellml/component.h
@@ -360,6 +360,19 @@ public:
      */
     bool hasReset(const ResetPtr &reset) const;
 
+    /**
+     * @brief Create a clone of this component.
+     *
+     * Creates a full separate copy of this component without copying
+     * the parent.  Thus the cloned (returned) version of this component
+     * will not have a parent set even if this component does.  Any and
+     * all child components will also be cloned recreating the full
+     * component hierarchy that this component is the root of.
+     *
+     * @return a new @c ComponentPtr to the cloned component.
+     */
+    ComponentPtr clone() const;
+
 private:
     Component(); /**< Constructor */
     explicit Component(const std::string &name);

--- a/src/api/libcellml/importsource.h
+++ b/src/api/libcellml/importsource.h
@@ -99,6 +99,16 @@ public:
      */
     bool hasModel() const;
 
+    /**
+     * @brief Create a clone of this import source.
+     *
+     * Creates a full separate copy of this import source without copying
+     * the parent.
+     *
+     * @return a new @c ImportSourcePtr to the cloned import source.
+     */
+    ImportSourcePtr clone() const;
+
 private:
     ImportSource(); /**< Constructor */
 

--- a/src/api/libcellml/model.h
+++ b/src/api/libcellml/model.h
@@ -271,6 +271,17 @@ public:
      */
     bool hasUnresolvedImports();
 
+    /**
+     * @brief Create a clone of this model.
+     *
+     * Creates a full separate copy of this model.  The component
+     * hierarchy and variable equivalence maps will also be copied
+     * from this model to the destination model.
+     *
+     * @return a new @c ModelPtr to the cloned model.
+     */
+    ModelPtr clone() const;
+
 private:
     Model(); /**< Constructor */
     explicit Model(const std::string &name); /**< Constructor with std::string parameter*/

--- a/src/api/libcellml/reset.h
+++ b/src/api/libcellml/reset.h
@@ -225,6 +225,16 @@ public:
      */
     std::string resetValueId() const;
 
+    /**
+     * @brief Create a clone of this reset.
+     *
+     * Creates a full separate copy of this reset without copying
+     * the parent.
+     *
+     * @return a new @c ResetPtr to the cloned reset.
+     */
+    ResetPtr clone() const;
+
 private:
     Reset(); /**< Constructor */
     explicit Reset(int order); /**< Constructor with int parameter */

--- a/src/api/libcellml/units.h
+++ b/src/api/libcellml/units.h
@@ -400,6 +400,8 @@ public:
      */
     static double scalingFactor(const UnitsPtr &units1, const UnitsPtr &units2);
 
+    UnitsPtr clone() const;
+
 private:
     Units(); /**< Constructor */
     explicit Units(const std::string &name); /**< Constructor with std::string parameter*/

--- a/src/api/libcellml/units.h
+++ b/src/api/libcellml/units.h
@@ -400,6 +400,15 @@ public:
      */
     static double scalingFactor(const UnitsPtr &units1, const UnitsPtr &units2);
 
+    /**
+     * @brief Create a clone of this units.
+     *
+     * Creates a full separate copy of this units without copying
+     * the parent. Thus the cloned (returned) version of this units
+     * will not have a parent set even if this units does.
+     *
+     * @return a new @c UnitsPtr to the cloned units.
+     */
     UnitsPtr clone() const;
 
 private:

--- a/src/api/libcellml/variable.h
+++ b/src/api/libcellml/variable.h
@@ -420,23 +420,11 @@ public:
      * will not have a parent set even if this variable does.
      *
      * If this variable has any equivalences these equivalences will
-     * *not* be cloned by default.  Use the @p cloneEquivalences
-     * parameter to change this behaviour.
-     *
-     * If this variable has a @c Units set the units will *not* be
-     * cloned by default.  Use the @p cloneUnits parameter to change
-     * this behaviour.  This means this variable and the clone variable
-     * will share the reference to the same @c Units if the units
-     * for this variable is set.
-     *
-     * @param cloneEquivalences Clone equivalences of this variable, the
-     * default position is to *not* clone equivalences.
-     * @param cloneUnits Clone the units of this variable (if any), the
-     * default position is to *not* clone units.
+     * *not* be cloned.
      *
      * @return a new @c VariablePtr to the cloned variable.
      */
-    VariablePtr clone(bool cloneEquivalences = false, bool cloneUnits = false) const;
+    VariablePtr clone() const;
 
 private:
     Variable(); /**< Constructor */

--- a/src/api/libcellml/variable.h
+++ b/src/api/libcellml/variable.h
@@ -419,9 +419,24 @@ public:
      * the parent.  Thus the cloned (returned) version of this variable
      * will not have a parent set even if this variable does.
      *
+     * If this variable has any equivalences these equivalences will
+     * *not* be cloned by default.  Use the @p cloneEquivalences
+     * parameter to change this behaviour.
+     *
+     * If this variable has a @c Units set the units will *not* be
+     * cloned by default.  Use the @p cloneUnits parameter to change
+     * this behaviour.  This means this variable and the clone variable
+     * will share the reference to the same @c Units if the units
+     * for this variable is set.
+     *
+     * @param cloneEquivalences Clone equivalences of this variable, the
+     * default position is to *not* clone equivalences.
+     * @param cloneUnits Clone the units of this variable (if any), the
+     * default position is to *not* clone units.
+     *
      * @return a new @c VariablePtr to the cloned variable.
      */
-    VariablePtr clone() const;
+    VariablePtr clone(bool cloneEquivalences = false, bool cloneUnits = false) const;
 
 private:
     Variable(); /**< Constructor */

--- a/src/api/libcellml/variable.h
+++ b/src/api/libcellml/variable.h
@@ -150,6 +150,7 @@ public:
      *
      * @param variable1Variable one of the equivalence.
      * @param variable2 Variable two of the equivalence.
+     *
      * @return the @c std::string mapping id.
      */
     static std::string equivalenceMappingId(const VariablePtr &variable1, const VariablePtr &variable2);
@@ -356,6 +357,8 @@ public:
      * Get the string corresponding to the initial value for this variable.
      *
      * @sa setInitialValue
+     *
+     * @return the initial value as a @c std::string.
      */
     std::string initialValue() const;
 
@@ -397,6 +400,8 @@ public:
      * Get the string corresponding to the interface type for this variable.
      *
      * @sa setInterfaceType
+     *
+     * @return the interface type as a @c std::string.
      */
     std::string interfaceType() const;
 
@@ -406,6 +411,17 @@ public:
      * Clears the interface type for this variable.
      */
     void removeInterfaceType();
+
+    /**
+     * @brief Create a clone of this variable.
+     *
+     * Creates a full separate copy of this variable without copying
+     * the parent.  Thus the cloned (returned) version of this variable
+     * will not have a parent set even if this variable does.
+     *
+     * @return a new @c VariablePtr to the cloned variable.
+     */
+    VariablePtr clone() const;
 
 private:
     Variable(); /**< Constructor */

--- a/src/bindings/interface/component.i
+++ b/src/bindings/interface/component.i
@@ -92,6 +92,9 @@ range for the index is [0, #resets).";
 resets. Returns True if the :param: reset is in this component's
 resets and False otherwise.";
 
+%feature("docstring") libcellml::Component::clone
+"Create a copy of this component.";
+
 #if defined(SWIGPYTHON)
     // Treat negative size_t as invalid index (instead of unknown method)
     %extend libcellml::Component {

--- a/src/bindings/interface/importsource.i
+++ b/src/bindings/interface/importsource.i
@@ -28,6 +28,9 @@ unset).";
 %feature("docstring") libcellml::ImportSource::hasModel
 "Returns True if this ImportSource has been resolved, False otherwise.";
 
+%feature("docstring") libcellml::ImportSource::clone
+"Create a copy of this import source.";
+
 %{
 #include "libcellml/importsource.h"
 %}

--- a/src/bindings/interface/model.i
+++ b/src/bindings/interface/model.i
@@ -58,6 +58,8 @@ determine the full path to the source model relative to this one.";
 %feature("docstring") libcellml::Model::hasUnresolvedImports
 "Tests if this model has unresolved imports.";
 
+%feature("docstring") libcellml::Model::clone
+"Create a copy of this model.";
 
 #if defined(SWIGPYTHON)
     // Treat negative size_t as invalid index (instead of unknown method)

--- a/src/bindings/interface/reset.i
+++ b/src/bindings/interface/reset.i
@@ -63,6 +63,9 @@
 %feature("docstring") libcellml::Reset::resetValueId
 "Returns the :class: reset_value id string of this reset.";
 
+%feature("docstring") libcellml::Reset::clone
+"Create a copy of this reset.";
+
 #if defined(SWIGPYTHON)
     // Allow any type of input to be converted to bool
     %typemap(typecheck,precedence=SWIG_TYPECHECK_BOOL) bool { $1 = 1; }

--- a/src/bindings/interface/units.i
+++ b/src/bindings/interface/units.i
@@ -76,6 +76,9 @@ extract the units with the given `name`.";
 %feature("docstring") libcellml::Units::scalingFactor
 "Returns the scaling factor between two Units objects.";
 
+%feature("docstring") libcellml::Units::clone
+"Create a copy of this units.";
+
 #if defined(SWIGPYTHON)
     // Treat negative size_t as invalid index (instead of unknown method)
     %extend libcellml::Units {

--- a/src/bindings/interface/variable.i
+++ b/src/bindings/interface/variable.i
@@ -93,6 +93,9 @@ not equivalent the connection id is not set.";
 %feature("docstring") libcellml::Variable::removeEquivalenceMappingId
 "Remove the mapping id for the equivalence defined with the given variables.";
 
+%feature("docstring") libcellml::Variable::clone
+"Create a copy of this variable.";
+
 #if defined(SWIGPYTHON)
     // Treat negative size_t as invalid index (instead of unknown method)
     %extend libcellml::Variable {

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -282,4 +282,9 @@ bool Component::hasReset(const ResetPtr &reset) const
     return mPimpl->findReset(reset) != mPimpl->mResets.end();
 }
 
+ComponentPtr Component::clone() const
+{
+    return create();
+}
+
 } // namespace libcellml

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -282,6 +282,21 @@ bool Component::hasReset(const ResetPtr &reset) const
     return mPimpl->findReset(reset) != mPimpl->mResets.end();
 }
 
+size_t getVariableIndexInComponent(const std::shared_ptr<const Component> &component, const VariablePtr &variable)
+{
+    size_t index = 0;
+    bool found = false;
+    while (index < component->variableCount() && !found) {
+        if (component->variable(index) == variable) {
+            found = true;
+        } else {
+            ++index;
+        }
+    }
+
+    return index;
+}
+
 ComponentPtr Component::clone() const
 {
     auto c = create();
@@ -300,7 +315,18 @@ ComponentPtr Component::clone() const
 
     for (size_t index = 0; index < resetCount(); ++index) {
         auto r = reset(index);
-        c->addReset(r->clone());
+        auto rClone = r->clone();
+        c->addReset(rClone);
+        size_t variableIndex = getVariableIndexInComponent(shared_from_this(), r->variable());
+        if (variableIndex < variableCount()) {
+            auto v = c->variable(variableIndex);
+            rClone->setVariable(v);
+        }
+        size_t testVariableIndex = getVariableIndexInComponent(shared_from_this(), r->testVariable());
+        if (testVariableIndex < variableCount()) {
+            auto v = c->variable(testVariableIndex);
+            rClone->setTestVariable(v);
+        }
     }
 
     for (size_t index = 0; index < componentCount(); ++index) {

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -203,8 +203,7 @@ VariablePtr Component::variable(const std::string &name) const
 
 VariablePtr Component::takeVariable(size_t index)
 {
-    VariablePtr res = nullptr;
-    res = variable(index);
+    VariablePtr res = variable(index);
     removeVariable(index);
 
     return res;
@@ -212,8 +211,7 @@ VariablePtr Component::takeVariable(size_t index)
 
 VariablePtr Component::takeVariable(const std::string &name)
 {
-    VariablePtr res = nullptr;
-    res = variable(name);
+    VariablePtr res = variable(name);
     removeVariable(name);
 
     return res;
@@ -291,6 +289,9 @@ ComponentPtr Component::clone() const
     c->setId(id());
     c->setName(name());
     c->setMath(math());
+
+    c->setImportSource(importSource());
+    c->setImportReference(importReference());
 
     for (size_t index = 0; index < variableCount(); ++index) {
         auto v = variable(index);

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -20,8 +20,10 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "libcellml/reset.h"
 #include "libcellml/units.h"
 #include "libcellml/variable.h"
+
 #include "utilities.h"
 
 namespace libcellml {
@@ -284,7 +286,28 @@ bool Component::hasReset(const ResetPtr &reset) const
 
 ComponentPtr Component::clone() const
 {
-    return create();
+    auto c = create();
+
+    c->setId(id());
+    c->setName(name());
+    c->setMath(math());
+
+    for (size_t index = 0; index < variableCount(); ++index) {
+        auto v = variable(index);
+        c->addVariable(v->clone());
+    }
+
+    for (size_t index = 0; index < resetCount(); ++index) {
+        auto r = reset(index);
+        c->addReset(r->clone());
+    }
+
+    for (size_t index = 0; index < componentCount(); ++index) {
+        auto cChild = component(index);
+        c->addComponent(cChild->clone());
+    }
+
+    return c;
 }
 
 } // namespace libcellml

--- a/src/debug.h
+++ b/src/debug.h
@@ -23,7 +23,7 @@ namespace libcellml {
 
 struct Debug
 {
-    Debug(bool newLine = true)
+    explicit Debug(bool newLine = true)
         : mNewLine(newLine)
     {
     }

--- a/src/debug.h
+++ b/src/debug.h
@@ -23,11 +23,17 @@ namespace libcellml {
 
 struct Debug
 {
-    Debug() = default;
+    Debug(bool newLine = true)
+        : mNewLine(newLine)
+    {
+    }
 
     ~Debug()
     {
-        std::cout << mSS.str() << std::endl;
+        std::cout << mSS.str();
+        if (mNewLine) {
+            std::cout << std::endl;
+        }
     }
 
     Debug &operator<<(const void *p)
@@ -48,6 +54,7 @@ struct Debug
 
 private:
     std::ostringstream mSS;
+    bool mNewLine;
 };
 
 } // namespace libcellml

--- a/src/importsource.cpp
+++ b/src/importsource.cpp
@@ -71,4 +71,15 @@ bool ImportSource::hasModel() const
     return mPimpl->mModel != nullptr;
 }
 
+ImportSourcePtr ImportSource::clone() const
+{
+    auto i = create();
+
+    i->setId(id());
+    i->setUrl(url());
+    i->setModel(model());
+
+    return i;
+}
+
 } // namespace libcellml

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -471,35 +471,6 @@ void applyEquivalenceMapToModel(const EquivalenceMap &map, const ModelPtr &model
     }
 }
 
-/*
-void printStack(const IndexStack &stack)
-{
-    Debug(false) << "[";
-    for (auto iter = stack.begin(); iter < stack.end(); ++iter) {
-        Debug(false) << *iter;
-        if (iter + 1 < stack.end()) {
-            Debug(false) << ", ";
-        }
-    }
-    Debug() << "]";
-}
-
-void printEquivalenceMap(const EquivalenceMap &map)
-{
-    Debug() << "Print out of equivalence map";
-    for (EquivalenceMap::const_iterator iter = map.begin(); iter != map.end(); ++iter) {
-        auto key = iter->first;
-        Debug(false) << "key: ";
-        printStack(key);
-        auto vector = iter->second;
-        for (auto vectorIt = vector.begin(); vectorIt < vector.end(); ++vectorIt) {
-            Debug(false) << "value: ";
-            printStack(*vectorIt);
-        }
-    }
-}
-*/
-
 ModelPtr Model::clone() const
 {
     auto m = create();
@@ -519,7 +490,6 @@ ModelPtr Model::clone() const
 
     auto map = generateEquivalenceMap(shared_from_this());
     applyEquivalenceMapToModel(map, m);
-    // printEquivalenceMap(map);
 
     return m;
 }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -342,21 +342,6 @@ bool Model::hasUnresolvedImports()
 using IndexStack = std::vector<size_t>; /**< Type definition for tracking indicies. */
 using EquivalenceMap = std::map<IndexStack, std::vector<IndexStack>>; /**< Type definition for map of variable equivalences defined over model. */
 
-size_t getVariableIndexInComponent(const ComponentPtr &component, const VariablePtr &variable)
-{
-    size_t index = 0;
-    bool found = false;
-    while (index < component->variableCount() && !found) {
-        if (component->variable(index) == variable) {
-            found = true;
-        } else {
-            ++index;
-        }
-    }
-
-    return index;
-}
-
 size_t getComponentIndexInComponentEntity(const ComponentEntityPtr &componentParent, const ComponentEntityPtr &component)
 {
     size_t index = 0;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -423,7 +423,7 @@ void generateEquivalenceMap(const ComponentPtr &component, EquivalenceMap &map, 
     }
 }
 
-EquivalenceMap generateEquivalenceMap(std::shared_ptr<const libcellml::Model> model)
+EquivalenceMap generateEquivalenceMap(const std::shared_ptr<const libcellml::Model> &model)
 {
     EquivalenceMap map;
 
@@ -439,7 +439,7 @@ EquivalenceMap generateEquivalenceMap(std::shared_ptr<const libcellml::Model> mo
     return map;
 }
 
-VariablePtr getVariableLocatedAt(const IndexStack &stack, ModelPtr model)
+VariablePtr getVariableLocatedAt(const IndexStack &stack, const ModelPtr &model)
 {
     ComponentPtr component;
     for (size_t index = 0; index < stack.size() - 1; ++index) {
@@ -453,18 +453,18 @@ VariablePtr getVariableLocatedAt(const IndexStack &stack, ModelPtr model)
     return component->variable(stack.back());
 }
 
-void makeEquivalence(const IndexStack &stack1, const IndexStack &stack2, ModelPtr model)
+void makeEquivalence(const IndexStack &stack1, const IndexStack &stack2, const ModelPtr &model)
 {
     auto v1 = getVariableLocatedAt(stack1, model);
     auto v2 = getVariableLocatedAt(stack2, model);
     Variable::addEquivalence(v1, v2);
 }
 
-void applyEquivalenceMapToModel(const EquivalenceMap &map, ModelPtr model)
+void applyEquivalenceMapToModel(const EquivalenceMap &map, const ModelPtr &model)
 {
-    for (EquivalenceMap::const_iterator iter = map.begin(); iter != map.end(); ++iter) {
-        auto key = iter->first;
-        auto vector = iter->second;
+    for (const auto & iter : map) {
+        auto key = iter.first;
+        auto vector = iter.second;
         for (auto vectorIter = vector.begin(); vectorIter < vector.end(); ++vectorIter) {
             makeEquivalence(key, *vectorIter, model);
         }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -406,7 +406,7 @@ void recordVariableEquivalences(const ComponentPtr &component, EquivalenceMap &e
             }
             equivalenceMap[indexStack].push_back(equivalentVariableIndexStack);
         }
-        if (variable->equivalentVariableCount()) {
+        if (variable->equivalentVariableCount() > 0) {
             indexStack.pop_back();
         }
     }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -341,8 +341,8 @@ bool Model::hasUnresolvedImports()
     return unresolvedImports;
 }
 
-using IndexStack = std::vector< size_t >;
-using EquivalenceMap = std::map< IndexStack, std::vector< IndexStack > >; /**< Type definition for map of variable equivalences defined over model. */
+using IndexStack = std::vector<size_t>; /**< Type definition for tracking indicies. */
+using EquivalenceMap = std::map<IndexStack, std::vector<IndexStack>>; /**< Type definition for map of variable equivalences defined over model. */
 
 size_t getVariableIndexInComponent(const ComponentPtr &component, const VariablePtr &variable)
 {
@@ -410,7 +410,7 @@ void recordVariableEquivalences(const ComponentPtr &component, EquivalenceMap &e
             auto equivalentVariable = variable->equivalentVariable(j);
             auto equivalentVariableIndexStack = reverseEngineerIndexStack(equivalentVariable);
             if (equivalenceMap.count(indexStack) == 0) {
-                equivalenceMap[indexStack] = std::vector< IndexStack >();
+                equivalenceMap[indexStack] = std::vector<IndexStack>();
             }
             equivalenceMap[indexStack].push_back(equivalentVariableIndexStack);
         }
@@ -525,7 +525,7 @@ ModelPtr Model::clone() const
 
     auto map = generateEquivalenceMap(shared_from_this());
     applyEquivalenceMapToModel(map, m);
-//    printEquivalenceMap(map);
+    // printEquivalenceMap(map);
 
     return m;
 }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -32,8 +32,6 @@ limitations under the License.
 
 #include "utilities.h"
 
-#include "debug.h"
-
 namespace libcellml {
 
 /**
@@ -356,9 +354,6 @@ size_t getVariableIndexInComponent(const ComponentPtr &component, const Variable
         }
     }
 
-    if (!found) {
-        Debug() << "Not found variable in parent Component!!!!";
-    }
     return index;
 }
 
@@ -374,9 +369,6 @@ size_t getComponentIndexInComponentEntity(const ComponentEntityPtr &componentPar
         }
     }
 
-    if (!found) {
-        Debug() << "Not found component in parent Entity!!!!";
-    }
     return index;
 }
 
@@ -479,6 +471,7 @@ void applyEquivalenceMapToModel(const EquivalenceMap &map, ModelPtr model)
     }
 }
 
+/*
 void printStack(const IndexStack &stack)
 {
     Debug(false) << "[";
@@ -505,6 +498,7 @@ void printEquivalenceMap(const EquivalenceMap &map)
         }
     }
 }
+*/
 
 ModelPtr Model::clone() const
 {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -408,22 +408,6 @@ void generateEquivalenceMap(const ComponentPtr &component, EquivalenceMap &map, 
     }
 }
 
-EquivalenceMap generateEquivalenceMap(const std::shared_ptr<const libcellml::Model> &model)
-{
-    EquivalenceMap map;
-
-    IndexStack indexStack;
-    for (size_t index = 0; index < model->componentCount(); ++index) {
-        indexStack.push_back(index);
-        auto c = model->component(index);
-        recordVariableEquivalences(c, map, indexStack);
-        generateEquivalenceMap(c, map, indexStack);
-        indexStack.pop_back();
-    }
-
-    return map;
-}
-
 VariablePtr getVariableLocatedAt(const IndexStack &stack, const ModelPtr &model)
 {
     ComponentPtr component;
@@ -473,7 +457,16 @@ ModelPtr Model::clone() const
         m->addComponent(component(index)->clone());
     }
 
-    auto map = generateEquivalenceMap(shared_from_this());
+    // Generate equivalence map starting from the models components.
+    EquivalenceMap map;
+    IndexStack indexStack;
+    for (size_t index = 0; index < componentCount(); ++index) {
+        indexStack.push_back(index);
+        auto c = component(index);
+        recordVariableEquivalences(c, map, indexStack);
+        generateEquivalenceMap(c, map, indexStack);
+        indexStack.pop_back();
+    }
     applyEquivalenceMapToModel(map, m);
 
     return m;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -339,4 +339,10 @@ bool Model::hasUnresolvedImports()
     return unresolvedImports;
 }
 
+ModelPtr Model::clone() const
+{
+    auto m = create();
+    return m;
+}
+
 } // namespace libcellml

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -462,7 +462,7 @@ void makeEquivalence(const IndexStack &stack1, const IndexStack &stack2, const M
 
 void applyEquivalenceMapToModel(const EquivalenceMap &map, const ModelPtr &model)
 {
-    for (const auto & iter : map) {
+    for (const auto &iter : map) {
         auto key = iter.first;
         auto vector = iter.second;
         for (auto vectorIter = vector.begin(); vectorIter < vector.end(); ++vectorIter) {

--- a/src/reset.cpp
+++ b/src/reset.cpp
@@ -19,6 +19,8 @@ limitations under the License.
 #include <algorithm>
 #include <vector>
 
+#include "libcellml/variable.h"
+
 namespace libcellml {
 
 /**
@@ -151,6 +153,26 @@ void Reset::removeResetValueId()
 std::string Reset::resetValueId() const
 {
     return mPimpl->mResetValueId;
+}
+
+ResetPtr Reset::clone() const
+{
+    auto r = create();
+
+    r->setId(id());
+    r->setOrder(order());
+    r->setResetValue(resetValue());
+    r->setResetValueId(resetValueId());
+    r->setTestValue(testValue());
+    r->setTestValueId(testValueId());
+    if (mPimpl->mVariable != nullptr) {
+        r->setVariable(mPimpl->mVariable->clone());
+    }
+    if (mPimpl->mTestVariable != nullptr) {
+        r->setTestVariable(mPimpl->mTestVariable->clone());
+    }
+
+    return r;
 }
 
 } // namespace libcellml

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -473,8 +473,11 @@ UnitsPtr Units::clone() const
     units->setImportSource(importSource());
     units->setImportReference(importReference());
 
-    std::string reference, prefix, id;
-    double exponent, multiplier;
+    std::string reference;
+    std::string prefix;
+    std::string id;
+    double exponent;
+    double multiplier;
     for (size_t index = 0; index < mPimpl->mUnits.size(); ++index) {
         unitAttributes(index, reference, prefix, exponent, multiplier, id);
         units->addUnit(reference, prefix, exponent, multiplier, id);

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -473,6 +473,13 @@ UnitsPtr Units::clone() const
     units->setImportSource(importSource());
     units->setImportReference(importReference());
 
+    std::string reference, prefix, id;
+    double exponent, multiplier;
+    for (size_t index = 0; index < mPimpl->mUnits.size(); ++index) {
+        unitAttributes(index, reference, prefix, exponent, multiplier, id);
+        units->addUnit(reference, prefix, exponent, multiplier, id);
+    }
+
     return units;
 }
 

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -460,4 +460,16 @@ double Units::scalingFactor(const UnitsPtr &units1, const UnitsPtr &units2)
     return 0.0;
 }
 
+UnitsPtr Units::clone() const
+{
+    auto units = create();
+
+    units->setId(id());
+    units->setName(name());
+    units->setImportSource(importSource());
+    units->setImportReference(importReference());
+
+    return units;
+}
+
 } // namespace libcellml

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -442,4 +442,19 @@ void removeComponentFromEntity(const EntityPtr &entity, const ComponentPtr &comp
     componentEntity->removeComponent(component, false);
 }
 
+size_t getVariableIndexInComponent(const ComponentPtr &component, const VariablePtr &variable)
+{
+    size_t index = 0;
+    bool found = false;
+    while (index < component->variableCount() && !found) {
+        if (component->variable(index) == variable) {
+            found = true;
+        } else {
+            ++index;
+        }
+    }
+
+    return index;
+}
+
 } // namespace libcellml

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -403,4 +403,18 @@ bool isStandardUnitName(const std::string &name);
  */
 bool isStandardPrefixName(const std::string &name);
 
+/**
+ * @brief Get the index of the @p variable in the @p component.
+ *
+ * Searches through the @p component for the @p variable returning the index
+ * of the @p variable if it was found.  If the @p variable was not found then
+ * the number of variables in the @p component is returned.
+ *
+ * @param component The @c ComponentPtr to search for the @c VariablePtr in.
+ * @param variable The @c VariablePtr to return the index of.
+ * @return The index of the @p variable found in the component.  Returns the
+ * number of variables in the component if the variable was not found.
+ */
+size_t getVariableIndexInComponent(const ComponentPtr &component, const VariablePtr &variable);
+
 } // namespace libcellml

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -485,26 +485,15 @@ void Variable::removeEquivalenceMappingId(const VariablePtr &variable1, const Va
     }
 }
 
-VariablePtr Variable::clone(bool cloneEquivalences, bool cloneUnits) const
+VariablePtr Variable::clone() const
 {
     auto v = create();
 
-    if (cloneUnits) {
-
-    } else {
-        v->setUnits(units());
-    }
+    v->setUnits(units());
     v->setInitialValue(initialValue());
     v->setInterfaceType(interfaceType());
     v->setId(id());
     v->setName(name());
-
-    if (cloneEquivalences) {
-        for (size_t i = 0; i < equivalentVariableCount(); ++i) {
-            auto variable = equivalentVariable(i);
-            addEquivalence(v, variable, mPimpl->equivalentMappingId(variable), mPimpl->equivalentConnectionId(variable));
-        }
-    }
 
     return v;
 }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -485,4 +485,9 @@ void Variable::removeEquivalenceMappingId(const VariablePtr &variable1, const Va
     }
 }
 
+VariablePtr Variable::clone() const
+{
+    return create();
+}
+
 } // namespace libcellml

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -489,7 +489,9 @@ VariablePtr Variable::clone() const
 {
     auto v = create();
 
-    v->setUnits(units());
+    if (mPimpl->mUnits != nullptr) {
+        v->setUnits(mPimpl->mUnits->name());
+    }
     v->setInitialValue(initialValue());
     v->setInterfaceType(interfaceType());
     v->setId(id());

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -485,9 +485,28 @@ void Variable::removeEquivalenceMappingId(const VariablePtr &variable1, const Va
     }
 }
 
-VariablePtr Variable::clone() const
+VariablePtr Variable::clone(bool cloneEquivalences, bool cloneUnits) const
 {
-    return create();
+    auto v = create();
+
+    if (cloneUnits) {
+
+    } else {
+        v->setUnits(units());
+    }
+    v->setInitialValue(initialValue());
+    v->setInterfaceType(interfaceType());
+    v->setId(id());
+    v->setName(name());
+
+    if (cloneEquivalences) {
+        for (size_t i = 0; i < equivalentVariableCount(); ++i) {
+            auto variable = equivalentVariable(i);
+            addEquivalence(v, variable, mPimpl->equivalentMappingId(variable), mPimpl->equivalentConnectionId(variable));
+        }
+    }
+
+    return v;
 }
 
 } // namespace libcellml

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ mark_as_advanced(gtest_force_shared_crt)
 # to the LIBCELLML_TESTS list.  Any source files for the
 # test must be set to <test_name>_SRCS, likewise for
 # header files <test_name>_HDRS.
+include(clone/tests.cmake)
 include(component/tests.cmake)
 include(connection/tests.cmake)
 include(coverage/tests.cmake)

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -365,6 +365,42 @@ TEST(Clone, componentWithResets)
     compareComponent(c, cClone);
 }
 
+TEST(Clone, componentWithResetsAndVariables)
+{
+    auto c = libcellml::Component::create();
+    auto r1 = libcellml::Reset::create();
+    auto r2 = libcellml::Reset::create();
+    auto v1 = libcellml::Variable::create();
+    auto v2 = libcellml::Variable::create();
+    auto v3 = libcellml::Variable::create();
+    auto v4 = libcellml::Variable::create();
+
+    c->setId("unique");
+    c->setName("copy");
+
+    v1->setName("variable1");
+    v2->setName("variable2");
+    v3->setName("variable3");
+    v4->setName("variable4");
+
+    r1->setVariable(v2);
+    r1->setTestVariable(v3);
+
+    r2->setTestVariable(v4);
+
+    c->addVariable(v1);
+    c->addVariable(v2);
+    c->addVariable(v3);
+    c->addVariable(v4);
+
+    c->addReset(r1);
+    c->addReset(r2);
+
+    auto cClone = c->clone();
+
+    compareComponent(c, cClone);
+}
+
 TEST(Clone, componentWithChildren)
 {
     auto c = libcellml::Component::create();

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -310,6 +310,15 @@ void compareComponent(const libcellml::ComponentPtr &c1, const libcellml::Compon
         auto c2i = c2->component(index);
         compareComponent(c1i, c2i, c2);
     }
+    for (size_t index = 0; index < c2->resetCount(); ++index) {
+        auto r = c2->reset(index);
+        if (r->variable() != nullptr) {
+            EXPECT_TRUE(c2->hasVariable(r->variable()));
+        }
+        if (r->testVariable() != nullptr) {
+            EXPECT_TRUE(c2->hasVariable(r->testVariable()));
+        }
+    }
 }
 
 TEST(Clone, component)
@@ -491,8 +500,13 @@ TEST(Clone, model)
 TEST(Clone, modelWithUnits)
 {
     auto m = libcellml::Model::create();
+    auto u = libcellml::Units::create();
+
+    u->setName("jangle");
     m->setId("unique_model");
     m->setName("model");
+
+    m->addUnits(u);
 
     auto mClone = m->clone();
 
@@ -516,6 +530,8 @@ TEST(Clone, modelWithComponents)
 
     c->addComponent(c1);
     c->addComponent(c2);
+
+    m->addComponent(c);
 
     auto mClone = m->clone();
 

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -24,8 +24,16 @@ void compareUnit(const libcellml::UnitsPtr &u1, const libcellml::UnitsPtr &u2)
 {
     EXPECT_EQ(u1->unitCount(), u2->unitCount());
 
-    std::string reference1, prefix1, id1, reference2, prefix2, id2;
-    double exponent1, multiplier1, exponent2, multiplier2;
+    std::string reference1;
+    std::string prefix1;
+    std::string id1;
+    std::string reference2;
+    std::string prefix2;
+    std::string id2;
+    double exponent1;
+    double multiplier1;
+    double exponent2;
+    double multiplier2;
     for (size_t index = 0; index < u1->unitCount(); ++index) {
         u1->unitAttributes(index, reference1, prefix1, exponent1, multiplier1, id1);
         u2->unitAttributes(index, reference2, prefix2, exponent2, multiplier2, id2);

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -93,6 +93,24 @@ TEST(Clone, unitsImportedUnits)
     compareUnits(u, uClone);
 }
 
+TEST(Clone, unitsImportedUnitsWithAdditionalUnit)
+{
+    auto u = libcellml::Units::create();
+
+    auto import = libcellml::ImportSource::create();
+    import->setUrl("some-other-model.xml");
+
+    u->setId("unique_id");
+    u->setName("units");
+    u->setSourceUnits(import, "imported_units_name");
+    u->addUnit(libcellml::Units::StandardUnit::LUMEN);
+    u->addUnit("a", "milli", -2.0);
+
+    auto uClone = u->clone();
+
+    compareUnits(u, uClone);
+}
+
 TEST(Clone, unitsInModel)
 {
     auto m = libcellml::Model::create();

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -93,6 +93,20 @@ TEST(Clone, unitsImportedUnits)
     compareUnits(u, uClone);
 }
 
+TEST(Clone, unitsWithUnit)
+{
+    auto u = libcellml::Units::create();
+
+    u->setId("unique_id");
+    u->setName("units");
+    u->addUnit(libcellml::Units::StandardUnit::LUMEN);
+    u->addUnit("meter", "milli", -2.0);
+
+    auto uClone = u->clone();
+
+    compareUnits(u, uClone);
+}
+
 TEST(Clone, unitsImportedUnitsWithAdditionalUnit)
 {
     auto u = libcellml::Units::create();

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -23,16 +23,98 @@ limitations under the License.
 TEST(Clone, variable)
 {
     auto v = libcellml::Variable::create();
+    v->setUnits("lightning");
+    v->setInitialValue(-3.0);
+    v->setInterfaceType(libcellml::Variable::InterfaceType::PRIVATE);
+    v->setId("id_unique");
+    v->setName("variable");
+
     auto vClone = v->clone();
 
+    EXPECT_EQ(nullptr, vClone->parent());
+    EXPECT_NE(v->units(), vClone->units());
+    EXPECT_EQ(v->initialValue(), vClone->initialValue());
+    EXPECT_EQ(v->interfaceType(), vClone->interfaceType());
+    EXPECT_EQ(v->id(), vClone->id());
     EXPECT_EQ(v->name(), vClone->name());
+
+    vClone->setUnits("on_my_own");
+    vClone->setInitialValue("45.0");
+    vClone->setInterfaceType("public");
+    vClone->setId("unique_again");
+    vClone->setName("on_my_own");
+
+    EXPECT_NE(v->units(), vClone->units());
+    EXPECT_EQ(v->initialValue(), "-3");
+    EXPECT_EQ(v->interfaceType(), "private");
+    EXPECT_EQ(v->id(), "id_unique");
+    EXPECT_EQ(v->name(), "variable");
+}
+
+TEST(Clone, variableWithUnitsPtrSet)
+{
+    auto u = libcellml::Units::create();
+    u->setName("daves");
+
+    auto v = libcellml::Variable::create();
+    v->setUnits(u);
+
+    auto vClone = v->clone();
+
+    EXPECT_NE(v->units(), vClone->units());
+    EXPECT_EQ(v->units()->name(), vClone->units()->name());
+    EXPECT_EQ(nullptr, vClone->units()->parent());
+}
+
+TEST(Clone, variableWithEquivalences)
+{
+    auto m = libcellml::Model::create();
+    auto u = libcellml::Units::create();
+    u->setName("daves");
+    m->addUnits(u);
+
+    auto c = libcellml::Component::create();
+    m->addComponent(c);
+
+    auto v = libcellml::Variable::create();
+    v->setUnits(u);
+
+    c->addVariable(v);
+
+    auto vClone = v->clone(true);
+}
+
+TEST(Clone, variableInModel)
+{
+    auto m = libcellml::Model::create();
+    auto u = libcellml::Units::create();
+    u->setName("daves");
+    m->addUnits(u);
+
+    auto c = libcellml::Component::create();
+    m->addComponent(c);
+
+    auto v = libcellml::Variable::create();
+    v->setUnits(u);
+
+    c->addVariable(v);
+
+    auto vClone = v->clone();
+    EXPECT_EQ(nullptr, vClone->parent());
+    EXPECT_NE(v->units(), vClone->units());
+    EXPECT_EQ(nullptr, vClone->units()->parent());
 }
 
 TEST(Clone, component)
 {
     auto c = libcellml::Component::create();
+    c->setName("copy");
+
     auto cClone = c->clone();
 
     EXPECT_EQ(c->name(), cClone->name());
+
+    cClone->setName("on_my_own");
+    EXPECT_NE(c->name(), cClone->name());
 }
 

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -1,0 +1,38 @@
+/*
+Copyright libCellML Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "gtest/gtest.h"
+
+#include <libcellml>
+
+#include "test_utils.h"
+
+TEST(Clone, variable)
+{
+    auto v = libcellml::Variable::create();
+    auto vClone = v->clone();
+
+    EXPECT_EQ(v->name(), vClone->name());
+}
+
+TEST(Clone, component)
+{
+    auto c = libcellml::Component::create();
+    auto cClone = c->clone();
+
+    EXPECT_EQ(c->name(), cClone->name());
+}
+

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -20,6 +20,94 @@ limitations under the License.
 
 #include "test_utils.h"
 
+void compareUnit(const libcellml::UnitsPtr &u1, const libcellml::UnitsPtr &u2)
+{
+    EXPECT_EQ(u1->unitCount(), u2->unitCount());
+
+    std::string reference1, prefix1, id1, reference2, prefix2, id2;
+    double exponent1, multiplier1, exponent2, multiplier2;
+    for (size_t index = 0; index < u1->unitCount(); ++index) {
+        u1->unitAttributes(index, reference1, prefix1, exponent1, multiplier1, id1);
+        u2->unitAttributes(index, reference2, prefix2, exponent2, multiplier2, id2);
+
+        EXPECT_EQ(reference1, reference2);
+        EXPECT_EQ(prefix1, prefix2);
+        EXPECT_EQ(exponent1, exponent2);
+        EXPECT_EQ(multiplier1, multiplier2);
+        EXPECT_EQ(id1, id2);
+    }
+}
+
+void compareUnits(const libcellml::UnitsPtr &u1, const libcellml::UnitsPtr &u2)
+{
+    EXPECT_EQ(u1->id(), u2->id());
+    EXPECT_EQ(u1->isBaseUnit(), u2->isBaseUnit());
+    EXPECT_EQ(u1->isImport(), u2->isImport());
+    EXPECT_EQ(u1->importReference(), u2->importReference());
+    EXPECT_EQ(u1->name(), u2->name());
+    EXPECT_EQ(nullptr, u2->parent());
+
+    compareUnit(u1, u2);
+}
+
+TEST(Clone, importSource)
+{
+    auto i = libcellml::ImportSource::create();
+
+    i->setId("import");
+    i->setUrl("this_is_a_url");
+
+    auto iClone = i->clone();
+
+    EXPECT_EQ(i->id(), iClone->id());
+    EXPECT_EQ(i->url(), iClone->url());
+    EXPECT_EQ(i->hasModel(), iClone->hasModel());
+}
+
+TEST(Clone, unitsBaseUnits)
+{
+    auto u = libcellml::Units::create();
+
+    u->setId("unique_id");
+    u->setName("units");
+    u->setImportReference("a_url");
+
+    auto uClone = u->clone();
+
+    compareUnits(u, uClone);
+}
+
+TEST(Clone, unitsImportedUnits)
+{
+    auto u = libcellml::Units::create();
+
+    auto import = libcellml::ImportSource::create();
+    import->setUrl("some-other-model.xml");
+
+    u->setId("unique_id");
+    u->setName("units");
+    u->setSourceUnits(import, "imported_units_name");
+
+    auto uClone = u->clone();
+
+    compareUnits(u, uClone);
+}
+
+TEST(Clone, unitsInModel)
+{
+    auto m = libcellml::Model::create();
+    auto u = libcellml::Units::create();
+
+    u->setId("unique_id");
+    u->setName("units");
+
+    m->addUnits(u);
+
+    auto uClone = u->clone();
+
+    compareUnits(u, uClone);
+}
+
 TEST(Clone, variable)
 {
     auto v = libcellml::Variable::create();

--- a/tests/clone/clone.cpp
+++ b/tests/clone/clone.cpp
@@ -418,3 +418,20 @@ TEST(Clone, componentWithImportAndChildren)
 
     compareComponent(c, cClone);
 }
+
+void compareModel(const libcellml::ModelPtr &m1, const libcellml::ModelPtr &m2)
+{
+    EXPECT_EQ(m1->id(), m2->id());
+    EXPECT_EQ(m1->name(), m2->name());
+}
+
+TEST(Clone, model)
+{
+    auto m = libcellml::Model::create();
+    m->setId("unique_model");
+    m->setName("model");
+
+    auto mClone = m->clone();
+
+    compareModel(m, mClone);
+}

--- a/tests/clone/tests.cmake
+++ b/tests/clone/tests.cmake
@@ -1,0 +1,18 @@
+
+# Set the test name, 'test_' will be prepended to the
+# name set here
+set(CURRENT_TEST clone)
+# Set a category name to enable running commands like:
+#    ctest -R <category-label>
+# which will run the tests matching this category-label.
+# Can be left empty (or just not set)
+set(${CURRENT_TEST}_CATEGORY utils)
+list(APPEND LIBCELLML_TESTS ${CURRENT_TEST})
+# Using absolute path relative to this file
+set(${CURRENT_TEST}_SRCS
+  ${CMAKE_CURRENT_LIST_DIR}/clone.cpp
+)
+set(${CURRENT_TEST}_HDRS
+)
+
+

--- a/tests/component/component.cpp
+++ b/tests/component/component.cpp
@@ -69,6 +69,12 @@ TEST(Component, invalidName)
     EXPECT_EQ("invalid name -", c->name());
 }
 
+TEST(Component, clone)
+{
+    libcellml::ComponentPtr c = libcellml::Component::create();
+    libcellml::ComponentPtr cc = c->clone();
+}
+
 TEST(Component, setAndUnsetName)
 {
     const std::string in = "name";

--- a/tests/component/component.cpp
+++ b/tests/component/component.cpp
@@ -69,12 +69,6 @@ TEST(Component, invalidName)
     EXPECT_EQ("invalid name -", c->name());
 }
 
-TEST(Component, clone)
-{
-    libcellml::ComponentPtr c = libcellml::Component::create();
-    libcellml::ComponentPtr cc = c->clone();
-}
-
 TEST(Component, setAndUnsetName)
 {
     const std::string in = "name";

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -39,11 +39,17 @@ const std::string NON_EMPTY_MATH =
 
 struct Debug
 {
-    Debug() = default;
+    Debug(bool newLine = true)
+        : mNewLine(newLine)
+    {
+    }
 
     ~Debug()
     {
-        std::cout << mSS.str() << std::endl;
+        std::cout << mSS.str();
+        if (mNewLine) {
+            std::cout << std::endl;
+        }
     }
 
     Debug &operator<<(const void *p)
@@ -64,6 +70,7 @@ struct Debug
 
 private:
     std::ostringstream mSS;
+    bool mNewLine;
 };
 
 std::string TEST_EXPORT resourcePath(const std::string &resourceRelativePath = "");

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -39,7 +39,7 @@ const std::string NON_EMPTY_MATH =
 
 struct Debug
 {
-    Debug(bool newLine = true)
+    explicit Debug(bool newLine = true)
         : mNewLine(newLine)
     {
     }


### PR DESCRIPTION
Adding clone method to all libCellML entities that are used by the `Model` class.

- [x] Model
- [x] Component
- [x] Variable
- [x] Units
- [x] ImportSource
- [x] Reset

Addresses #439.