### PR TITLE
Math parser: provide a way to ignore validation using the MathML DTD

### DIFF
--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -1128,7 +1128,7 @@ void Generator::GeneratorImpl::processComponent(const ComponentPtr &component)
     std::string math = component->math();
 
     if (!math.empty()) {
-        xmlDoc->parseMathML(math);
+        xmlDoc->parseMathML(math, false);
 
         XmlNodePtr mathNode = xmlDoc->rootNode();
 

--- a/src/xmldoc.cpp
+++ b/src/xmldoc.cpp
@@ -89,15 +89,18 @@ void XmlDoc::parse(const std::string &input)
     xmlCleanupGlobals();
 }
 
-void XmlDoc::parseMathML(const std::string &input)
+void XmlDoc::parseMathML(const std::string &input, bool validate)
 {
     xmlInitParser();
-    std::string mathmlDtd = "<!DOCTYPE math SYSTEM \"" + LIBCELLML_MATHML_DTD_LOCATION + "\">";
-    std::string mathmlString = mathmlDtd + input;
+    std::string mathmlString = input;
+    if (validate) {
+        mathmlString = "<!DOCTYPE math SYSTEM \"" + LIBCELLML_MATHML_DTD_LOCATION + "\">" + mathmlString;
+    }
     xmlParserCtxtPtr context = xmlNewParserCtxt();
     context->_private = reinterpret_cast<void *>(this);
     xmlSetStructuredErrorFunc(context, structuredErrorCallback);
-    mPimpl->mXmlDocPtr = xmlCtxtReadDoc(context, reinterpret_cast<const xmlChar *>(mathmlString.c_str()), "/", nullptr, XML_PARSE_DTDVALID);
+    mPimpl->mXmlDocPtr = xmlCtxtReadDoc(context, reinterpret_cast<const xmlChar *>(mathmlString.c_str()), "/", nullptr,
+                                        validate ? XML_PARSE_DTDVALID : 0);
     xmlFreeParserCtxt(context);
     xmlSetStructuredErrorFunc(nullptr, nullptr);
     xmlCleanupParser();

--- a/src/xmldoc.h
+++ b/src/xmldoc.h
@@ -53,8 +53,10 @@ public:
      * Parses the @p input @c std::string as a MathML string.
      *
      * @param input The @c std::string to parse.
+     * @param validate Optional parameter to determine whether validation
+     * against the MathML DTD should be done.
      */
-    void parseMathML(const std::string &input);
+    void parseMathML(const std::string &input, bool validate = true);
 
     /**
      * @brief Convert this @c XmlDoc content into a pretty-print @c std::string.


### PR DESCRIPTION
Addresses issue #551.