### PR TITLE
i586 Update checks to reflect new spec

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -342,12 +342,13 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
                 // and issue-checked in loadEncapsulation().
                 encapsulationNodes.push_back(componentRefNode);
             } else {
-                // TODO Should this be removed?
+                // Empty encapsulations are valid, but may not be intended.  This issue has been downgraded to a warning.
                 IssuePtr issue = Issue::create();
                 issue->setDescription("Encapsulation in model '" + model->name() + "' does not contain any child elements.");
                 issue->setModel(model);
                 issue->setCause(Issue::Cause::ENCAPSULATION);
                 issue->setReferenceRule(Issue::ReferenceRule::ENCAPSULATION_COMPONENT_REF);
+                issue->setLevel(libcellml::Issue::Level::WARNING);
                 mParser->addIssue(issue);
             }
         } else if (childNode->isCellmlElement("connection")) {
@@ -782,12 +783,12 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
     XmlNodePtr childNode = node->firstChild();
 
     if (!childNode) {
-        // TODO Should this be removed too?
         IssuePtr issue = Issue::create();
-        issue->setDescription("Connection in model '" + model->name() + "' must contain one or more 'map_variables' elements.");
+        issue->setDescription("Connection in model '" + model->name() + "' does not contain any 'map_variables' elements.");
         issue->setModel(model);
         issue->setCause(Issue::Cause::CONNECTION);
         issue->setReferenceRule(Issue::ReferenceRule::CONNECTION_MAP_VARIABLES);
+        issue->setLevel(libcellml::Issue::Level::WARNING);
         mParser->addIssue(issue);
         return;
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -342,7 +342,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
                 // and issue-checked in loadEncapsulation().
                 encapsulationNodes.push_back(componentRefNode);
             } else {
-                // Empty encapsulations are valid, but may not be intended.  This issue has been downgraded to a warning.
+                // Empty encapsulations are valid, but may not be intended.
                 IssuePtr issue = Issue::create();
                 issue->setDescription("Encapsulation in model '" + model->name() + "' does not contain any child elements.");
                 issue->setModel(model);

--- a/tests/parser/parser.cpp
+++ b/tests/parser/parser.cpp
@@ -646,6 +646,7 @@ TEST(Parser, emptyEncapsulation)
     libcellml::ParserPtr p = libcellml::Parser::create();
     p->parseModel(in);
     EXPECT_EQ_ISSUES(expectedIssues, p);
+    EXPECT_EQ(libcellml::Issue::Level::WARNING, p->issue(0)->level());
 }
 
 TEST(Parser, validEncapsulation)
@@ -984,11 +985,12 @@ TEST(Parser, emptyConnections)
     const std::vector<std::string> expectedIssues = {
         "Connection in model 'model_name' does not have a valid component_1 in a connection element.",
         "Connection in model 'model_name' does not have a valid component_2 in a connection element.",
-        "Connection in model 'model_name' must contain one or more 'map_variables' elements.",
+        "Connection in model 'model_name' does not contain any 'map_variables' elements.",
     };
 
     libcellml::ParserPtr p = libcellml::Parser::create();
     p->parseModel(in);
+    printIssues(p);
     EXPECT_EQ_ISSUES(expectedIssues, p);
 }
 
@@ -1104,8 +1106,8 @@ TEST(Parser, connectionErrorNoMapVariables)
         "</model>\n";
     const std::vector<std::string> expectedIssues = {
         "Connection in model '' has an invalid connection attribute 'component_3'.",
-        "Connection in model '' must contain one or more 'map_variables' elements.",
-        "Connection in model '' must contain one or more 'map_variables' elements.",
+        "Connection in model '' does not contain any 'map_variables' elements.",
+        "Connection in model '' does not contain any 'map_variables' elements.",
     };
 
     libcellml::ParserPtr p = libcellml::Parser::create();
@@ -1377,7 +1379,7 @@ TEST(Parser, invalidModelWithAllCausesOfIssues)
         "Connection in model 'starwars' has an invalid connection attribute 'wookie'.",
         "Connection in model 'starwars' does not have a valid component_1 in a connection element.",
         "Connection in model 'starwars' does not have a valid component_2 in a connection element.",
-        "Connection in model 'starwars' must contain one or more 'map_variables' elements.",
+        "Connection in model 'starwars' does not contain any 'map_variables' elements.",
     };
 
     // Parse and check for CellML issues.

--- a/tests/parser/parser.cpp
+++ b/tests/parser/parser.cpp
@@ -990,7 +990,6 @@ TEST(Parser, emptyConnections)
 
     libcellml::ParserPtr p = libcellml::Parser::create();
     p->parseModel(in);
-    printIssues(p);
     EXPECT_EQ_ISSUES(expectedIssues, p);
 }
 


### PR DESCRIPTION
Addresses #586 

Now that we're allowed to have empty encapsulations and connections, the errors returned from the parser about these have been downgraded to warnings, and the message updated to match.