### PR TITLE
I629 Fixed parser bug for reading mapping ids

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -376,7 +376,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
     }
 
     if (!encapsulationNodes.empty()) {
-        loadEncapsulation(model, encapsulationNodes[0]);
+        loadEncapsulation(model, encapsulationNodes.at(0));
         if (encapsulationNodes.size() > 1) {
             IssuePtr issue = Issue::create();
             issue->setDescription("Model '" + model->name() + "' has more than one encapsulation element.");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -726,9 +726,10 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
     // Define types for variable and component pairs, and their ids.
     using NameInfo = std::vector<std::string>;
     using NameInfoMap = std::vector<NameInfo>;
+    using NamePair = std::pair<std::string, std::string>;
 
     // Initialise name pairs and flags.
-    NameInfo componentNameInfo;
+    NamePair componentNamePair;
     NameInfo variableNameInfo;
     NameInfoMap variableNameMap;
     bool mapVariablesFound = false;
@@ -778,7 +779,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
         mParser->addIssue(issue);
         component2Missing = true;
     }
-    componentNameInfo = {component1Name, component2Name};
+    componentNamePair = std::make_pair(component1Name, component2Name);
 
     XmlNodePtr childNode = node->firstChild();
 
@@ -892,24 +893,24 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
     ComponentPtr component1 = nullptr;
     ComponentPtr component2 = nullptr;
     // Now check the objects exist in the model. TODO Remove as is validation?
-    if (model->containsComponent(componentNameInfo[0])) {
-        component1 = model->component(componentNameInfo[0]);
+    if (model->containsComponent(componentNamePair.first)) {
+        component1 = model->component(componentNamePair.first);
     } else {
         if (!component1Missing) {
             IssuePtr issue = Issue::create();
-            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNameInfo[0] + "' as component_1 but it does not exist in the model.");
+            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNamePair.first + "' as component_1 but it does not exist in the model.");
             issue->setModel(model);
             issue->setCause(Issue::Cause::CONNECTION);
             issue->setReferenceRule(Issue::ReferenceRule::CONNECTION_COMPONENT1);
             mParser->addIssue(issue);
         }
     }
-    if (model->containsComponent(componentNameInfo[1])) {
-        component2 = model->component(componentNameInfo[1]);
+    if (model->containsComponent(componentNamePair.second)) {
+        component2 = model->component(componentNamePair.second);
     } else {
         if (!component2Missing) {
             IssuePtr issue = Issue::create();
-            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNameInfo[1] + "' as component_2 but it does not exist in the model.");
+            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNamePair.second + "' as component_2 but it does not exist in the model.");
             issue->setModel(model);
             issue->setCause(Issue::Cause::CONNECTION);
             issue->setReferenceRule(Issue::ReferenceRule::CONNECTION_COMPONENT2);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -376,7 +376,7 @@ void Parser::ParserImpl::loadModel(const ModelPtr &model, const std::string &inp
     }
 
     if (!encapsulationNodes.empty()) {
-        loadEncapsulation(model, encapsulationNodes.at(0));
+        loadEncapsulation(model, encapsulationNodes[0]);
         if (encapsulationNodes.size() > 1) {
             IssuePtr issue = Issue::create();
             issue->setDescription("Model '" + model->name() + "' has more than one encapsulation element.");
@@ -824,7 +824,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
             std::string variable1Name;
             std::string variable2Name;
             XmlAttributePtr childAttribute = childNode->firstAttribute();
-            mappingId = "";
+            mappingId.clear();
             while (childAttribute) {
                 if (childAttribute->isType("variable_1")) {
                     variable1Name = childAttribute->value();
@@ -892,24 +892,24 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
     ComponentPtr component1 = nullptr;
     ComponentPtr component2 = nullptr;
     // Now check the objects exist in the model. TODO Remove as is validation?
-    if (model->containsComponent(componentNamePair.at(0))) {
-        component1 = model->component(componentNamePair.at(0));
+    if (model->containsComponent(componentNamePair[0])) {
+        component1 = model->component(componentNamePair[0]);
     } else {
         if (!component1Missing) {
             IssuePtr issue = Issue::create();
-            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNamePair.at(0) + "' as component_1 but it does not exist in the model.");
+            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNamePair[0] + "' as component_1 but it does not exist in the model.");
             issue->setModel(model);
             issue->setCause(Issue::Cause::CONNECTION);
             issue->setReferenceRule(Issue::ReferenceRule::CONNECTION_COMPONENT1);
             mParser->addIssue(issue);
         }
     }
-    if (model->containsComponent(componentNamePair.at(1))) {
-        component2 = model->component(componentNamePair.at(1));
+    if (model->containsComponent(componentNamePair[1])) {
+        component2 = model->component(componentNamePair[1]);
     } else {
         if (!component2Missing) {
             IssuePtr issue = Issue::create();
-            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNamePair.at(1) + "' as component_2 but it does not exist in the model.");
+            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNamePair[1] + "' as component_2 but it does not exist in the model.");
             issue->setModel(model);
             issue->setCause(Issue::Cause::CONNECTION);
             issue->setReferenceRule(Issue::ReferenceRule::CONNECTION_COMPONENT2);
@@ -923,17 +923,17 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
             VariablePtr variable1 = nullptr;
             VariablePtr variable2 = nullptr;
             if (component1) {
-                if (component1->hasVariable(iterPair.at(0))) {
-                    variable1 = component1->variable(iterPair.at(0));
+                if (component1->hasVariable(iterPair[0])) {
+                    variable1 = component1->variable(iterPair[0]);
                 } else if (component1->isImport()) {
                     // With an imported component we assume this variable exists in the imported component.
                     variable1 = Variable::create();
-                    variable1->setName(iterPair.at(0));
+                    variable1->setName(iterPair[0]);
                     component1->addVariable(variable1);
                 } else {
                     if (!variable1Missing) {
                         IssuePtr issue = Issue::create();
-                        issue->setDescription("Variable '" + iterPair.at(0) + "' is specified as variable_1 in a connection but it does not exist in component_1 component '" + component1->name() + "' of model '" + model->name() + "'.");
+                        issue->setDescription("Variable '" + iterPair[0] + "' is specified as variable_1 in a connection but it does not exist in component_1 component '" + component1->name() + "' of model '" + model->name() + "'.");
                         issue->setComponent(component1);
                         issue->setCause(Issue::Cause::CONNECTION);
                         issue->setReferenceRule(Issue::ReferenceRule::MAP_VARIABLES_VARIABLE1);
@@ -942,24 +942,24 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
                 }
             } else {
                 IssuePtr issue = Issue::create();
-                issue->setDescription("Connection in model '" + model->name() + "' specifies '" + iterPair.at(0) + "' as variable_1 but the corresponding component_1 is invalid.");
+                issue->setDescription("Connection in model '" + model->name() + "' specifies '" + iterPair[0] + "' as variable_1 but the corresponding component_1 is invalid.");
                 issue->setModel(model);
                 issue->setCause(Issue::Cause::CONNECTION);
                 issue->setReferenceRule(Issue::ReferenceRule::MAP_VARIABLES_VARIABLE1);
                 mParser->addIssue(issue);
             }
             if (component2) {
-                if (component2->hasVariable(iterPair.at(1))) {
-                    variable2 = component2->variable(iterPair.at(1));
+                if (component2->hasVariable(iterPair[1])) {
+                    variable2 = component2->variable(iterPair[1]);
                 } else if (component2->isImport()) {
                     // With an imported component we assume this variable exists in the imported component.
                     variable2 = Variable::create();
-                    variable2->setName(iterPair.at(1));
+                    variable2->setName(iterPair[1]);
                     component2->addVariable(variable2);
                 } else {
                     if (!variable2Missing) {
                         IssuePtr issue = Issue::create();
-                        issue->setDescription("Variable '" + iterPair.at(1) + "' is specified as variable_2 in a connection but it does not exist in component_2 component '" + component2->name() + "' of model '" + model->name() + "'.");
+                        issue->setDescription("Variable '" + iterPair[1] + "' is specified as variable_2 in a connection but it does not exist in component_2 component '" + component2->name() + "' of model '" + model->name() + "'.");
                         issue->setComponent(component1);
                         issue->setCause(Issue::Cause::CONNECTION);
                         issue->setReferenceRule(Issue::ReferenceRule::MAP_VARIABLES_VARIABLE2);
@@ -968,7 +968,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
                 }
             } else {
                 IssuePtr issue = Issue::create();
-                issue->setDescription("Connection in model '" + model->name() + "' specifies '" + iterPair.at(1) + "' as variable_2 but the corresponding component_2 is invalid.");
+                issue->setDescription("Connection in model '" + model->name() + "' specifies '" + iterPair[1] + "' as variable_2 but the corresponding component_2 is invalid.");
                 issue->setModel(model);
                 issue->setCause(Issue::Cause::CONNECTION);
                 issue->setReferenceRule(Issue::ReferenceRule::MAP_VARIABLES_VARIABLE2);
@@ -976,7 +976,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
             }
             // Set the variable equivalence relationship for this variable pair.
             if ((variable1) && (variable2)) {
-                Variable::addEquivalence(variable1, variable2, iterPair.at(2), connectionId);
+                Variable::addEquivalence(variable1, variable2, iterPair[2], connectionId);
             }
         }
     } else {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -723,14 +723,14 @@ void Parser::ParserImpl::loadVariable(const VariablePtr &variable, const XmlNode
 
 void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr &node) const
 {
-    // Define types for variable and component pairs.
-    using NamePair = std::vector<std::string>;
-    using NamePairMap = std::vector<NamePair>;
+    // Define types for variable and component pairs, and their ids.
+    using NameInfo = std::vector<std::string>;
+    using NameInfoMap = std::vector<NameInfo>;
 
     // Initialise name pairs and flags.
-    NamePair componentNamePair;
-    NamePair variableNameInfo;
-    NamePairMap variableNameMap;
+    NameInfo componentNameInfo;
+    NameInfo variableNameInfo;
+    NameInfoMap variableNameMap;
     bool mapVariablesFound = false;
     bool component1Missing = false;
     bool component2Missing = false;
@@ -778,7 +778,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
         mParser->addIssue(issue);
         component2Missing = true;
     }
-    componentNamePair = {component1Name, component2Name};
+    componentNameInfo = {component1Name, component2Name};
 
     XmlNodePtr childNode = node->firstChild();
 
@@ -892,24 +892,24 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
     ComponentPtr component1 = nullptr;
     ComponentPtr component2 = nullptr;
     // Now check the objects exist in the model. TODO Remove as is validation?
-    if (model->containsComponent(componentNamePair[0])) {
-        component1 = model->component(componentNamePair[0]);
+    if (model->containsComponent(componentNameInfo[0])) {
+        component1 = model->component(componentNameInfo[0]);
     } else {
         if (!component1Missing) {
             IssuePtr issue = Issue::create();
-            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNamePair[0] + "' as component_1 but it does not exist in the model.");
+            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNameInfo[0] + "' as component_1 but it does not exist in the model.");
             issue->setModel(model);
             issue->setCause(Issue::Cause::CONNECTION);
             issue->setReferenceRule(Issue::ReferenceRule::CONNECTION_COMPONENT1);
             mParser->addIssue(issue);
         }
     }
-    if (model->containsComponent(componentNamePair[1])) {
-        component2 = model->component(componentNamePair[1]);
+    if (model->containsComponent(componentNameInfo[1])) {
+        component2 = model->component(componentNameInfo[1]);
     } else {
         if (!component2Missing) {
             IssuePtr issue = Issue::create();
-            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNamePair[1] + "' as component_2 but it does not exist in the model.");
+            issue->setDescription("Connection in model '" + model->name() + "' specifies '" + componentNameInfo[1] + "' as component_2 but it does not exist in the model.");
             issue->setModel(model);
             issue->setCause(Issue::Cause::CONNECTION);
             issue->setReferenceRule(Issue::ReferenceRule::CONNECTION_COMPONENT2);
@@ -919,21 +919,21 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
 
     // If we have a map_variables, check that the variables exist in the named components. TODO Remove as is validation?
     if (mapVariablesFound) {
-        for (const auto &iterPair : variableNameMap) {
+        for (const auto &iterInfo : variableNameMap) {
             VariablePtr variable1 = nullptr;
             VariablePtr variable2 = nullptr;
             if (component1) {
-                if (component1->hasVariable(iterPair[0])) {
-                    variable1 = component1->variable(iterPair[0]);
+                if (component1->hasVariable(iterInfo[0])) {
+                    variable1 = component1->variable(iterInfo[0]);
                 } else if (component1->isImport()) {
                     // With an imported component we assume this variable exists in the imported component.
                     variable1 = Variable::create();
-                    variable1->setName(iterPair[0]);
+                    variable1->setName(iterInfo[0]);
                     component1->addVariable(variable1);
                 } else {
                     if (!variable1Missing) {
                         IssuePtr issue = Issue::create();
-                        issue->setDescription("Variable '" + iterPair[0] + "' is specified as variable_1 in a connection but it does not exist in component_1 component '" + component1->name() + "' of model '" + model->name() + "'.");
+                        issue->setDescription("Variable '" + iterInfo[0] + "' is specified as variable_1 in a connection but it does not exist in component_1 component '" + component1->name() + "' of model '" + model->name() + "'.");
                         issue->setComponent(component1);
                         issue->setCause(Issue::Cause::CONNECTION);
                         issue->setReferenceRule(Issue::ReferenceRule::MAP_VARIABLES_VARIABLE1);
@@ -942,24 +942,24 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
                 }
             } else {
                 IssuePtr issue = Issue::create();
-                issue->setDescription("Connection in model '" + model->name() + "' specifies '" + iterPair[0] + "' as variable_1 but the corresponding component_1 is invalid.");
+                issue->setDescription("Connection in model '" + model->name() + "' specifies '" + iterInfo[0] + "' as variable_1 but the corresponding component_1 is invalid.");
                 issue->setModel(model);
                 issue->setCause(Issue::Cause::CONNECTION);
                 issue->setReferenceRule(Issue::ReferenceRule::MAP_VARIABLES_VARIABLE1);
                 mParser->addIssue(issue);
             }
             if (component2) {
-                if (component2->hasVariable(iterPair[1])) {
-                    variable2 = component2->variable(iterPair[1]);
+                if (component2->hasVariable(iterInfo[1])) {
+                    variable2 = component2->variable(iterInfo[1]);
                 } else if (component2->isImport()) {
                     // With an imported component we assume this variable exists in the imported component.
                     variable2 = Variable::create();
-                    variable2->setName(iterPair[1]);
+                    variable2->setName(iterInfo[1]);
                     component2->addVariable(variable2);
                 } else {
                     if (!variable2Missing) {
                         IssuePtr issue = Issue::create();
-                        issue->setDescription("Variable '" + iterPair[1] + "' is specified as variable_2 in a connection but it does not exist in component_2 component '" + component2->name() + "' of model '" + model->name() + "'.");
+                        issue->setDescription("Variable '" + iterInfo[1] + "' is specified as variable_2 in a connection but it does not exist in component_2 component '" + component2->name() + "' of model '" + model->name() + "'.");
                         issue->setComponent(component1);
                         issue->setCause(Issue::Cause::CONNECTION);
                         issue->setReferenceRule(Issue::ReferenceRule::MAP_VARIABLES_VARIABLE2);
@@ -968,7 +968,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
                 }
             } else {
                 IssuePtr issue = Issue::create();
-                issue->setDescription("Connection in model '" + model->name() + "' specifies '" + iterPair[1] + "' as variable_2 but the corresponding component_2 is invalid.");
+                issue->setDescription("Connection in model '" + model->name() + "' specifies '" + iterInfo[1] + "' as variable_2 but the corresponding component_2 is invalid.");
                 issue->setModel(model);
                 issue->setCause(Issue::Cause::CONNECTION);
                 issue->setReferenceRule(Issue::ReferenceRule::MAP_VARIABLES_VARIABLE2);
@@ -976,7 +976,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
             }
             // Set the variable equivalence relationship for this variable pair.
             if ((variable1) && (variable2)) {
-                Variable::addEquivalence(variable1, variable2, iterPair[2], connectionId);
+                Variable::addEquivalence(variable1, variable2, iterInfo[2], connectionId);
             }
         }
     } else {

--- a/tests/connection/connection.cpp
+++ b/tests/connection/connection.cpp
@@ -1161,3 +1161,42 @@ TEST(Connection, componentConnectionAndParseMissingVariable)
     const std::string a = printer->printModel(model);
     EXPECT_EQ(e, a);
 }
+
+TEST(Connection, mappingId)
+{
+    const std::string in = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                           "<model xmlns=\"http://www.cellml.org/cellml/2.0#\"  name=\"everything\" >\n"
+                           "  <component name=\"c1\" >\n"
+                           "    <variable name=\"v1\" units=\"units2\" interface=\"private\"/>\n"
+                           "  </component>\n"
+                           "  <component name=\"c2\">\n"
+                           "    <variable name=\"v2a\" units=\"units2\" interface=\"public\"/>\n"
+                           "    <variable name=\"v2b\" units=\"units2\" interface=\"public\"/>\n"
+                           "  </component>\n"
+                           "  <component name=\"c3\">\n"
+                           "    <variable name=\"v3\" units=\"units2\" interface=\"public\"/>\n"
+                           "  </component>\n"
+                           "  <connection component_1=\"c1\" component_2=\"c2\">\n"
+                           "    <map_variables variable_1=\"v1\" variable_2=\"v2a\" id=\"id12a\"/>\n"
+                           "    <map_variables variable_1=\"v1\" variable_2=\"v2b\" id=\"id12b\"/>\n"
+                           "  </connection>\n"
+                           "  <connection component_1=\"c1\" component_2=\"c3\">\n"
+                           "    <map_variables variable_1=\"v1\" variable_2=\"v3\" id=\"id13\"/>\n"
+                           "  </connection>\n"
+
+                           "</model>\n";
+    auto parser = libcellml::Parser::create();
+    auto model = parser->parseModel(in);
+    EXPECT_EQ("id12a",
+              libcellml::Variable::equivalenceMappingId(
+                  model->component("c1")->variable("v1"),
+                  model->component("c2")->variable("v2a")));  // <<< Fails because id is "id12b"
+    EXPECT_EQ("id12b",
+              libcellml::Variable::equivalenceMappingId(
+                  model->component("c1")->variable("v1"),
+                  model->component("c2")->variable("v2b")));
+    EXPECT_EQ("id13",
+              libcellml::Variable::equivalenceMappingId(
+                  model->component("c1")->variable("v1"),
+                  model->component("c3")->variable("v3")));
+}

--- a/tests/connection/connection.cpp
+++ b/tests/connection/connection.cpp
@@ -1190,7 +1190,7 @@ TEST(Connection, mappingId)
     EXPECT_EQ("id12a",
               libcellml::Variable::equivalenceMappingId(
                   model->component("c1")->variable("v1"),
-                  model->component("c2")->variable("v2a")));  // <<< Fails because id is "id12b"
+                  model->component("c2")->variable("v2a")));
     EXPECT_EQ("id12b",
               libcellml::Variable::equivalenceMappingId(
                   model->component("c1")->variable("v1"),


### PR DESCRIPTION
Closes #629 

The `Parser` was not saving the id of parsed mappings, but rather using the last encountered `mappingId` for all mappings in a connection.  This is fixed here.