### PR TITLE
I641 add warnings for empty parsed blocks

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -783,7 +783,7 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
 
     XmlNodePtr childNode = node->firstChild();
 
-    if (!childNode) {
+    if (childNode == nullptr) {
         IssuePtr issue = Issue::create();
         std::string des = "Connection in model '" + model->name() + "'";
         if (connectionId.empty()) {
@@ -1160,7 +1160,7 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
     }
     XmlNodePtr childNode = node->firstChild();
 
-    if (!childNode) {
+    if (childNode == nullptr) {
         auto issue = Issue::create();
         if (id.empty()) {
             issue->setDescription("Import from '" + node->attribute("href") + "' is empty and will be disregarded.");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -787,10 +787,10 @@ void Parser::ParserImpl::loadConnection(const ModelPtr &model, const XmlNodePtr 
         IssuePtr issue = Issue::create();
         std::string des = "Connection in model '" + model->name() + "'";
         if (connectionId.empty()) {
-            des += " does not contain any 'map_variables' elements. It will not be loaded into the model.";
+            des += " does not contain any 'map_variables' elements and will be disregarded.";
         } else {
             des += " has an id of '" + connectionId + "' but does not contain any 'map_variables' elements.";
-            des += " The connection will not be loaded into the model, and the associated id bookmark will be lost.";
+            des += " The connection will be disregarded and the associated id will be lost.";
         }
         issue->setDescription(des);
         issue->setModel(model);
@@ -1163,9 +1163,9 @@ void Parser::ParserImpl::loadImport(const ImportSourcePtr &importSource, const M
     if (!childNode) {
         auto issue = Issue::create();
         if (id.empty()) {
-            issue->setDescription("Import from '" + node->attribute("href") + "' is empty. It will not be loaded into the model.");
+            issue->setDescription("Import from '" + node->attribute("href") + "' is empty and will be disregarded.");
         } else {
-            issue->setDescription("Import from '" + node->attribute("href") + "' has an id of '" + id + "' but is empty. It will not be loaded into the model, and the associated id bookmark will be lost.");
+            issue->setDescription("Import from '" + node->attribute("href") + "' has an id of '" + id + "' but is empty. The import will be disregarded and the associated id will be lost.");
         }
         issue->setImportSource(importSource);
         issue->setCause(libcellml::Issue::Cause::IMPORT);

--- a/tests/parser/parser.cpp
+++ b/tests/parser/parser.cpp
@@ -985,7 +985,7 @@ TEST(Parser, emptyConnections)
     const std::vector<std::string> expectedIssues = {
         "Connection in model 'model_name' does not have a valid component_1 in a connection element.",
         "Connection in model 'model_name' does not have a valid component_2 in a connection element.",
-        "Connection in model 'model_name' does not contain any 'map_variables' elements. It will not be loaded into the model.",
+        "Connection in model 'model_name' does not contain any 'map_variables' elements and will be disregarded.",
     };
 
     libcellml::ParserPtr p = libcellml::Parser::create();
@@ -1003,7 +1003,7 @@ TEST(Parser, emptyConnectionWithId)
     const std::vector<std::string> expectedIssues = {
         "Connection in model 'model_name' does not have a valid component_1 in a connection element.",
         "Connection in model 'model_name' does not have a valid component_2 in a connection element.",
-        "Connection in model 'model_name' has an id of 'myId' but does not contain any 'map_variables' elements. The connection will not be loaded into the model, and the associated id bookmark will be lost.",
+        "Connection in model 'model_name' has an id of 'myId' but does not contain any 'map_variables' elements. The connection will be disregarded and the associated id will be lost.",
     };
 
     libcellml::ParserPtr p = libcellml::Parser::create();
@@ -1123,8 +1123,8 @@ TEST(Parser, connectionErrorNoMapVariables)
         "</model>\n";
     const std::vector<std::string> expectedIssues = {
         "Connection in model '' has an invalid connection attribute 'component_3'.",
-        "Connection in model '' does not contain any 'map_variables' elements. It will not be loaded into the model.",
-        "Connection in model '' does not contain any 'map_variables' elements. It will not be loaded into the model.",
+        "Connection in model '' does not contain any 'map_variables' elements and will be disregarded.",
+        "Connection in model '' does not contain any 'map_variables' elements and will be disregarded.",
     };
 
     libcellml::ParserPtr p = libcellml::Parser::create();
@@ -1163,8 +1163,8 @@ TEST(Parser, emptyImportWithAndWithoutId)
         "  <import id = \"import_id\" />\n"
         "</model>\n";
     std::vector<std::string> e = {
-        "Import from '' is empty. It will not be loaded into the model.",
-        "Import from '' has an id of 'import_id' but is empty. It will not be loaded into the model, and the associated id bookmark will be lost.",
+        "Import from '' is empty and will be disregarded.",
+        "Import from '' has an id of 'import_id' but is empty. The import will be disregarded and the associated id will be lost.",
     };
     libcellml::ParserPtr parser = libcellml::Parser::create();
     auto m = parser->parseModel(in);
@@ -1405,7 +1405,7 @@ TEST(Parser, invalidModelWithAllCausesOfIssues)
     const std::vector<std::string> expectedIssues = {
         "Model 'starwars' has an invalid attribute 'episode'.",
         "Import from '' has an invalid attribute 'princess'.",
-        "Import from '' is empty. It will not be loaded into the model.",
+        "Import from '' is empty and will be disregarded.",
         "Units '' has an invalid attribute 'jedi'.",
         "Component '' has an invalid attribute 'ship'.",
         "Variable '' has an invalid attribute 'pilot'.",
@@ -1414,7 +1414,7 @@ TEST(Parser, invalidModelWithAllCausesOfIssues)
         "Connection in model 'starwars' has an invalid connection attribute 'wookie'.",
         "Connection in model 'starwars' does not have a valid component_1 in a connection element.",
         "Connection in model 'starwars' does not have a valid component_2 in a connection element.",
-        "Connection in model 'starwars' does not contain any 'map_variables' elements. It will not be loaded into the model.",
+        "Connection in model 'starwars' does not contain any 'map_variables' elements and will be disregarded.",
     };
 
     // Parse and check for CellML issues.

--- a/tests/parser/parser.cpp
+++ b/tests/parser/parser.cpp
@@ -985,7 +985,25 @@ TEST(Parser, emptyConnections)
     const std::vector<std::string> expectedIssues = {
         "Connection in model 'model_name' does not have a valid component_1 in a connection element.",
         "Connection in model 'model_name' does not have a valid component_2 in a connection element.",
-        "Connection in model 'model_name' does not contain any 'map_variables' elements.",
+        "Connection in model 'model_name' does not contain any 'map_variables' elements. It will not be loaded into the model.",
+    };
+
+    libcellml::ParserPtr p = libcellml::Parser::create();
+    p->parseModel(in);
+    EXPECT_EQ_ISSUES(expectedIssues, p);
+}
+
+TEST(Parser, emptyConnectionWithId)
+{
+    const std::string in =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<model xmlns=\"http://www.cellml.org/cellml/2.0#\" name=\"model_name\">\n"
+        "  <connection id=\"myId\"/>\n"
+        "</model>\n";
+    const std::vector<std::string> expectedIssues = {
+        "Connection in model 'model_name' does not have a valid component_1 in a connection element.",
+        "Connection in model 'model_name' does not have a valid component_2 in a connection element.",
+        "Connection in model 'model_name' has an id of 'myId' but does not contain any 'map_variables' elements. The connection will not be loaded into the model, and the associated id bookmark will be lost.",
     };
 
     libcellml::ParserPtr p = libcellml::Parser::create();
@@ -1105,8 +1123,8 @@ TEST(Parser, connectionErrorNoMapVariables)
         "</model>\n";
     const std::vector<std::string> expectedIssues = {
         "Connection in model '' has an invalid connection attribute 'component_3'.",
-        "Connection in model '' does not contain any 'map_variables' elements.",
-        "Connection in model '' does not contain any 'map_variables' elements.",
+        "Connection in model '' does not contain any 'map_variables' elements. It will not be loaded into the model.",
+        "Connection in model '' does not contain any 'map_variables' elements. It will not be loaded into the model.",
     };
 
     libcellml::ParserPtr p = libcellml::Parser::create();
@@ -1134,6 +1152,23 @@ TEST(Parser, importedComponent2Connection)
     libcellml::ParserPtr parser = libcellml::Parser::create();
     parser->parseModel(e);
     EXPECT_EQ(size_t(0), parser->issueCount());
+}
+
+TEST(Parser, emptyImportWithId)
+{
+    const std::string in =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<model xmlns=\"http://www.cellml.org/cellml/2.0#\" name=\"model_name\">\n"
+        "  <import id = \"import_id\" />\n"
+        "</model>\n";
+    std::string e = {
+        "Import from '' has an id of 'import_id' but is empty. It will not be loaded into the model, and the associated id bookmark will be lost.",
+    };
+    libcellml::ParserPtr parser = libcellml::Parser::create();
+    auto m = parser->parseModel(in);
+    EXPECT_EQ(size_t(1), parser->issueCount());
+    EXPECT_EQ(e, parser->issue(0)->description());
+    EXPECT_EQ(libcellml::Issue::Level::WARNING, parser->issue(0)->level());
 }
 
 TEST(Parser, validConnectionMapVariablesFirst)
@@ -1370,6 +1405,7 @@ TEST(Parser, invalidModelWithAllCausesOfIssues)
     const std::vector<std::string> expectedIssues = {
         "Model 'starwars' has an invalid attribute 'episode'.",
         "Import from '' has an invalid attribute 'princess'.",
+        "Import from '' is empty. It will not be loaded into the model.",
         "Units '' has an invalid attribute 'jedi'.",
         "Component '' has an invalid attribute 'ship'.",
         "Variable '' has an invalid attribute 'pilot'.",
@@ -1378,7 +1414,7 @@ TEST(Parser, invalidModelWithAllCausesOfIssues)
         "Connection in model 'starwars' has an invalid connection attribute 'wookie'.",
         "Connection in model 'starwars' does not have a valid component_1 in a connection element.",
         "Connection in model 'starwars' does not have a valid component_2 in a connection element.",
-        "Connection in model 'starwars' does not contain any 'map_variables' elements.",
+        "Connection in model 'starwars' does not contain any 'map_variables' elements. It will not be loaded into the model.",
     };
 
     // Parse and check for CellML issues.
@@ -2039,4 +2075,8 @@ TEST(Parser, repeatedMathParsePrintBehaviourWithReset)
     std::string output2 = printer->printModel(model2);
 
     EXPECT_EQ(in, output2);
+}
+
+TEST(Parser, parseEmptyEncapsulationWithId)
+{
 }

--- a/tests/parser/parser.cpp
+++ b/tests/parser/parser.cpp
@@ -2076,7 +2076,3 @@ TEST(Parser, repeatedMathParsePrintBehaviourWithReset)
 
     EXPECT_EQ(in, output2);
 }
-
-TEST(Parser, parseEmptyEncapsulationWithId)
-{
-}

--- a/tests/parser/parser.cpp
+++ b/tests/parser/parser.cpp
@@ -1154,21 +1154,21 @@ TEST(Parser, importedComponent2Connection)
     EXPECT_EQ(size_t(0), parser->issueCount());
 }
 
-TEST(Parser, emptyImportWithId)
+TEST(Parser, emptyImportWithAndWithoutId)
 {
     const std::string in =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
         "<model xmlns=\"http://www.cellml.org/cellml/2.0#\" name=\"model_name\">\n"
+        "  <import/>"
         "  <import id = \"import_id\" />\n"
         "</model>\n";
-    std::string e = {
+    std::vector<std::string> e = {
+        "Import from '' is empty. It will not be loaded into the model.",
         "Import from '' has an id of 'import_id' but is empty. It will not be loaded into the model, and the associated id bookmark will be lost.",
     };
     libcellml::ParserPtr parser = libcellml::Parser::create();
     auto m = parser->parseModel(in);
-    EXPECT_EQ(size_t(1), parser->issueCount());
-    EXPECT_EQ(e, parser->issue(0)->description());
-    EXPECT_EQ(libcellml::Issue::Level::WARNING, parser->issue(0)->level());
+    EXPECT_EQ_ISSUES(e, parser);
 }
 
 TEST(Parser, validConnectionMapVariablesFirst)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -55,7 +55,8 @@ void printIssues(const libcellml::LoggerPtr &l, bool headings, bool causes, bool
         if (rule) {
             std::cout << ", " << static_cast<int>(l->issue(i)->referenceRule());
         }
-        std::cout << std::endl;
+        std::cout << std::endl
+                  << l->issue(i)->description() << std::endl;
     }
 }
 


### PR DESCRIPTION
Addresses #641 

Adds better warning messages when the parser encounters empty blocks (which are valid but not saved).