### PR TITLE
i717 Model::fixVariableInterfaces should not downgrade public_and_private to private

### DIFF
--- a/src/api/libcellml/variable.h
+++ b/src/api/libcellml/variable.h
@@ -435,12 +435,16 @@ public:
      * Test if this variable permits access through the @p interfaceType. The results
      * will be given according to this truth table:
      * 
-     *    argument : stored interface type = return value
-     *    (anything) : public_and_private = true
-     *    private : public = false
-     *    public : private = false
-     *    public, private, public_and_private : none = false
-     *    none : (anything) = true
+     *    Parameter (right) /
+     *   Stored value (below) | none | public | private | public_and_private  
+     *   ---------------------+------+--------+---------+-------------------
+     *                   none | T    | F      | F       | F
+     *   ---------------------+------+--------+---------+-------------------
+     *                 public | T    | T      | F       | F
+     *   ---------------------+------+--------+---------+-------------------
+     *                private | T    | F      | T       | F
+     *   ---------------------+------+--------+---------+-------------------
+     *     public_and_private | T    | T      | T       | T
      *
      * @param interfaceType The interface type to test for.
      *

--- a/src/api/libcellml/variable.h
+++ b/src/api/libcellml/variable.h
@@ -430,6 +430,25 @@ public:
     bool hasInterfaceType(InterfaceType interfaceType) const;
 
     /**
+     * @brief Test if this variable permits access through the @p interfaceType.
+     *
+     * Test if this variable permits access through the @p interfaceType. The results
+     * will be given according to this truth table:
+     * 
+     *    argument : stored interface type = return value
+     *    (anything) : public_and_private = true
+     *    private : public = false
+     *    public : private = false
+     *    public, private, public_and_private : none = false
+     *    none : (anything) = true
+     *
+     * @param interfaceType The interface type to test for.
+     *
+     * @return @c true if the interface type is acceptable, @c false otherwise.
+     */
+    bool hasMinimumInterfaceType(InterfaceType interfaceType) const;
+
+    /**
      * @brief Create a clone of this variable.
      *
      * Creates a full separate copy of this variable without copying

--- a/src/api/libcellml/variable.h
+++ b/src/api/libcellml/variable.h
@@ -448,9 +448,9 @@ public:
      *
      * @param interfaceType The interface type to test for.
      *
-     * @return @c true if the interface type is acceptable, @c false otherwise.
+     * @return @c true if the interface type is permitted, @c false otherwise.
      */
-    bool hasMinimumInterfaceType(InterfaceType interfaceType) const;
+    bool permitsInterfaceType(InterfaceType interfaceType) const;
 
     /**
      * @brief Create a clone of this variable.

--- a/src/bindings/interface/variable.i
+++ b/src/bindings/interface/variable.i
@@ -53,13 +53,16 @@ reference.";
 "Returns this variable's interface type as a string.";
 
 %feature("docstring") libcellml::Variable::hasInterfaceType
-"Test if this variable has the given interface type.";
+"Tests if this variable has the given interface type.";
+
+%feature("docstring") libcellml::Variable::hasMinimumInterfaceType
+"Tests if this variable will accept access through the given interface type.";
 
 %feature("docstring") libcellml::Variable::removeInterfaceType
-"Clear the interface type for this variable.";
+"Clears the interface type for this variable.";
 
 %feature("docstring") libcellml::Variable::removeInitialValue
-"Clears the intial value for this variable.";
+"Clears the initial value for this variable.";
 
 %feature("docstring") libcellml::Variable::setInterfaceType
 "Sets this variable's interfacetype to the given type specified as string or

--- a/src/bindings/interface/variable.i
+++ b/src/bindings/interface/variable.i
@@ -55,7 +55,7 @@ reference.";
 %feature("docstring") libcellml::Variable::hasInterfaceType
 "Tests if this variable has the given interface type.";
 
-%feature("docstring") libcellml::Variable::hasMinimumInterfaceType
+%feature("docstring") libcellml::Variable::permitsInterfaceType
 "Tests if this variable will accept access through the given interface type.";
 
 %feature("docstring") libcellml::Variable::removeInterfaceType

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -575,7 +575,7 @@ bool Model::fixVariableInterfaces()
         Variable::InterfaceType interfaceType = determineInterfaceType(variable);
         if (interfaceType == Variable::InterfaceType::NONE) {
             allOk = false;
-        } else if (!variable->hasMinimumInterfaceType(interfaceType)) {
+        } else if (!variable->permitsInterfaceType(interfaceType)) {
             variable->setInterfaceType(interfaceType);
         }
     }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -575,7 +575,7 @@ bool Model::fixVariableInterfaces()
         Variable::InterfaceType interfaceType = determineInterfaceType(variable);
         if (interfaceType == Variable::InterfaceType::NONE) {
             allOk = false;
-        } else if (!variable->hasInterfaceType(interfaceType)) {
+        } else if (!variable->hasMinimumInterfaceType(interfaceType)) {
             variable->setInterfaceType(interfaceType);
         }
     }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -495,9 +495,6 @@ bool Variable::permitsInterfaceType(InterfaceType interfaceType) const
     if (mPimpl->mInterfaceType == "public_and_private") {
         return true;
     }
-    if ((mPimpl->mInterfaceType == "none") || mPimpl->mInterfaceType.empty()) {
-        return false;
-    }
     return testString == mPimpl->mInterfaceType;
 }
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -487,14 +487,17 @@ bool Variable::hasInterfaceType(InterfaceType interfaceType) const
 
 bool Variable::hasMinimumInterfaceType(InterfaceType interfaceType) const
 {
-    /*
-     *    argument : stored interface type = return value
-     *    (anything) : public_and_private = true
-     *    private : public = false
-     *    public : private = false
-     *    public, private, public_and_private : none = false
-     *    none : (anything) = true
-     */
+    //  Parameter (right) /
+    // Stored value (below) | none | public | private | public_and_private  
+    // ---------------------+------+--------+---------+-------------------
+    //                 none | T    | F      | F       | F
+    // ---------------------+------+--------+---------+-------------------
+    //               public | T    | T      | F       | F
+    // ---------------------+------+--------+---------+-------------------
+    //              private | T    | F      | T       | F
+    // ---------------------+------+--------+---------+-------------------
+    //   public_and_private | T    | T      | T       | T
+     
     std::string testString = interfaceTypeToString.find(interfaceType)->second;
 
     if ((testString == "none") || testString.empty()) {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -485,19 +485,8 @@ bool Variable::hasInterfaceType(InterfaceType interfaceType) const
     return mPimpl->mInterfaceType == interfaceTypeToString.find(interfaceType)->second;
 }
 
-bool Variable::hasMinimumInterfaceType(InterfaceType interfaceType) const
+bool Variable::permitsInterfaceType(InterfaceType interfaceType) const
 {
-    //  Parameter (right) /
-    // Stored value (below) | none | public | private | public_and_private
-    // ---------------------+------+--------+---------+-------------------
-    //                 none | T    | F      | F       | F
-    // ---------------------+------+--------+---------+-------------------
-    //               public | T    | T      | F       | F
-    // ---------------------+------+--------+---------+-------------------
-    //              private | T    | F      | T       | F
-    // ---------------------+------+--------+---------+-------------------
-    //   public_and_private | T    | T      | T       | T
-
     std::string testString = interfaceTypeToString.find(interfaceType)->second;
 
     if ((testString == "none") || testString.empty()) {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -485,6 +485,30 @@ bool Variable::hasInterfaceType(InterfaceType interfaceType) const
     return mPimpl->mInterfaceType == interfaceTypeToString.find(interfaceType)->second;
 }
 
+bool Variable::hasMinimumInterfaceType(InterfaceType interfaceType) const
+{
+    /*
+     *    argument : stored interface type = return value
+     *    (anything) : public_and_private = true
+     *    private : public = false
+     *    public : private = false
+     *    public, private, public_and_private : none = false
+     *    none : (anything) = true
+     */
+    std::string testString = interfaceTypeToString.find(interfaceType)->second;
+
+    if ((testString == "none") || testString.empty()) {
+        return true;
+    }
+    if (mPimpl->mInterfaceType == "public_and_private") {
+        return true;
+    }
+    if ((mPimpl->mInterfaceType == "none") || mPimpl->mInterfaceType.empty()) {
+        return false;
+    }
+    return testString == mPimpl->mInterfaceType;
+}
+
 void Variable::setEquivalenceMappingId(const VariablePtr &variable1, const VariablePtr &variable2, const std::string &mappingId)
 {
     if (variable1->hasEquivalentVariable(variable2, true) && variable2->hasEquivalentVariable(variable1, true)) {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -488,7 +488,7 @@ bool Variable::hasInterfaceType(InterfaceType interfaceType) const
 bool Variable::hasMinimumInterfaceType(InterfaceType interfaceType) const
 {
     //  Parameter (right) /
-    // Stored value (below) | none | public | private | public_and_private  
+    // Stored value (below) | none | public | private | public_and_private
     // ---------------------+------+--------+---------+-------------------
     //                 none | T    | F      | F       | F
     // ---------------------+------+--------+---------+-------------------
@@ -497,7 +497,7 @@ bool Variable::hasMinimumInterfaceType(InterfaceType interfaceType) const
     //              private | T    | F      | T       | F
     // ---------------------+------+--------+---------+-------------------
     //   public_and_private | T    | T      | T       | T
-     
+
     std::string testString = interfaceTypeToString.find(interfaceType)->second;
 
     if ((testString == "none") || testString.empty()) {

--- a/tests/bindings/python/test_variable.py
+++ b/tests/bindings/python/test_variable.py
@@ -338,7 +338,6 @@ class VariableTestCase(unittest.TestCase):
         v.setInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE)
         self.assertEqual(v.interfaceType(), 'public_and_private')
 
-
     def test_minimum_interface_type(self):
         from libcellml import Variable
 

--- a/tests/bindings/python/test_variable.py
+++ b/tests/bindings/python/test_variable.py
@@ -338,6 +338,59 @@ class VariableTestCase(unittest.TestCase):
         v.setInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE)
         self.assertEqual(v.interfaceType(), 'public_and_private')
 
+
+    def test_minimum_interface_type(self):
+        from libcellml import Variable
+
+        v_public = Variable()
+        v_public.setName("v_public")
+        v_public.setInterfaceType("public")
+
+        v_private = Variable()
+        v_public.setName("v_private")
+        v_private.setInterfaceType("private")
+
+        v_public_and_private = Variable()
+        v_public_and_private.setName("v_public_and_private")
+        v_public_and_private.setInterfaceType("public_and_private")
+
+        v_none = Variable()
+        v_none.setName("v_none")
+        v_none.setInterfaceType("none")
+
+        v_empty = Variable()
+        v_empty.setName("v_empty")
+
+        # Stored public_and_private meets all requirements.
+        self.assertTrue(v_public_and_private.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
+        self.assertTrue(v_public_and_private.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertTrue(v_public_and_private.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertTrue(v_public_and_private.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+
+        # Stored private meets private and none requirements.
+        self.assertTrue(v_private.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
+        self.assertTrue(v_private.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertFalse(v_private.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertFalse(v_private.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+
+        # Stored public meets public and none requirements.
+        self.assertTrue(v_public.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
+        self.assertFalse(v_public.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertTrue(v_public.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertFalse(v_public.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+
+        # Stored none meets none requirements.
+        self.assertTrue(v_none.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
+        self.assertFalse(v_none.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertFalse(v_none.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertFalse(v_none.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+
+        # Stored empty meets none requirements.
+        self.assertTrue(v_empty.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
+        self.assertFalse(v_empty.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertFalse(v_empty.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertFalse(v_empty.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+
     def test_clone(self):
         from libcellml import Units, Variable
 

--- a/tests/bindings/python/test_variable.py
+++ b/tests/bindings/python/test_variable.py
@@ -361,34 +361,34 @@ class VariableTestCase(unittest.TestCase):
         v_empty.setName("v_empty")
 
         # Stored public_and_private meets all requirements.
-        self.assertTrue(v_public_and_private.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
-        self.assertTrue(v_public_and_private.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
-        self.assertTrue(v_public_and_private.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
-        self.assertTrue(v_public_and_private.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+        self.assertTrue(v_public_and_private.permitsInterfaceType(Variable.InterfaceType.NONE))
+        self.assertTrue(v_public_and_private.permitsInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertTrue(v_public_and_private.permitsInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertTrue(v_public_and_private.permitsInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
 
         # Stored private meets private and none requirements.
-        self.assertTrue(v_private.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
-        self.assertTrue(v_private.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
-        self.assertFalse(v_private.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
-        self.assertFalse(v_private.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+        self.assertTrue(v_private.permitsInterfaceType(Variable.InterfaceType.NONE))
+        self.assertTrue(v_private.permitsInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertFalse(v_private.permitsInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertFalse(v_private.permitsInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
 
         # Stored public meets public and none requirements.
-        self.assertTrue(v_public.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
-        self.assertFalse(v_public.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
-        self.assertTrue(v_public.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
-        self.assertFalse(v_public.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+        self.assertTrue(v_public.permitsInterfaceType(Variable.InterfaceType.NONE))
+        self.assertFalse(v_public.permitsInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertTrue(v_public.permitsInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertFalse(v_public.permitsInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
 
         # Stored none meets none requirements.
-        self.assertTrue(v_none.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
-        self.assertFalse(v_none.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
-        self.assertFalse(v_none.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
-        self.assertFalse(v_none.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+        self.assertTrue(v_none.permitsInterfaceType(Variable.InterfaceType.NONE))
+        self.assertFalse(v_none.permitsInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertFalse(v_none.permitsInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertFalse(v_none.permitsInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
 
         # Stored empty meets none requirements.
-        self.assertTrue(v_empty.hasMinimumInterfaceType(Variable.InterfaceType.NONE))
-        self.assertFalse(v_empty.hasMinimumInterfaceType(Variable.InterfaceType.PRIVATE))
-        self.assertFalse(v_empty.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC))
-        self.assertFalse(v_empty.hasMinimumInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
+        self.assertTrue(v_empty.permitsInterfaceType(Variable.InterfaceType.NONE))
+        self.assertFalse(v_empty.permitsInterfaceType(Variable.InterfaceType.PRIVATE))
+        self.assertFalse(v_empty.permitsInterfaceType(Variable.InterfaceType.PUBLIC))
+        self.assertFalse(v_empty.permitsInterfaceType(Variable.InterfaceType.PUBLIC_AND_PRIVATE))
 
     def test_clone(self):
         from libcellml import Units, Variable

--- a/tests/variable/variable.cpp
+++ b/tests/variable/variable.cpp
@@ -1736,11 +1736,66 @@ TEST(Variable, variableInterfaceDontDowngradeFromPublicAndPrivate)
     libcellml::Variable::addEquivalence(v1, v2);
     libcellml::Variable::addEquivalence(v2, v3);
 
-    EXPECT_FALSE(model->fixVariableInterfaces());
+    EXPECT_TRUE(model->fixVariableInterfaces());
 
     EXPECT_EQ("public_and_private", v1->interfaceType());
     EXPECT_EQ("public_and_private", v2->interfaceType());
     EXPECT_EQ("public", v3->interfaceType());
+}
+
+TEST(Variable, minimumInterfaceType)
+{
+    /*
+     *    argument : stored interface type = return value
+     *    (anything) : public_and_private = true
+     *    private : public = false
+     *    public : private = false
+     *    public, private, public_and_private : none = false
+     *    none : (anything) = true
+     */
+    auto vPublic = libcellml::Variable::create("vPublic");
+    vPublic->setInterfaceType("public");
+
+    auto vPrivate = libcellml::Variable::create("vPrivate");
+    vPrivate->setInterfaceType("private");
+
+    auto vPublicAndPrivate = libcellml::Variable::create("vPublicAndPrivate");
+    vPublicAndPrivate->setInterfaceType("public_and_private");
+
+    auto vNone = libcellml::Variable::create("vNone");
+    vNone->setInterfaceType("none");
+
+    auto vEmpty = libcellml::Variable::create("vEmpty");
+
+    // Stored public_and_private meets all requirements.
+    EXPECT_TRUE(vPublicAndPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_TRUE(vPublicAndPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_TRUE(vPublicAndPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_TRUE(vPublicAndPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+
+    // Stored private meets private and none requirements.
+    EXPECT_TRUE(vPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_TRUE(vPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_FALSE(vPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_FALSE(vPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+
+    // Stored public meets public and none requirements.
+    EXPECT_TRUE(vPublic->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_FALSE(vPublic->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_TRUE(vPublic->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_FALSE(vPublic->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+
+    // Stored none meets none requirements.
+    EXPECT_TRUE(vNone->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_FALSE(vNone->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_FALSE(vNone->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_FALSE(vNone->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+
+    // Stored empty meets none requirements.
+    EXPECT_TRUE(vEmpty->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_FALSE(vEmpty->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_FALSE(vEmpty->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_FALSE(vEmpty->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
 }
 
 TEST(Variable, connectionsPersistAfterImporting)

--- a/tests/variable/variable.cpp
+++ b/tests/variable/variable.cpp
@@ -1768,34 +1768,34 @@ TEST(Variable, minimumInterfaceType)
     auto vEmpty = libcellml::Variable::create("vEmpty");
 
     // Stored public_and_private meets all requirements.
-    EXPECT_TRUE(vPublicAndPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
-    EXPECT_TRUE(vPublicAndPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
-    EXPECT_TRUE(vPublicAndPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
-    EXPECT_TRUE(vPublicAndPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+    EXPECT_TRUE(vPublicAndPrivate->permitsInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_TRUE(vPublicAndPrivate->permitsInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_TRUE(vPublicAndPrivate->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_TRUE(vPublicAndPrivate->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
 
     // Stored private meets private and none requirements.
-    EXPECT_TRUE(vPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
-    EXPECT_TRUE(vPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
-    EXPECT_FALSE(vPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
-    EXPECT_FALSE(vPrivate->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+    EXPECT_TRUE(vPrivate->permitsInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_TRUE(vPrivate->permitsInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_FALSE(vPrivate->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_FALSE(vPrivate->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
 
     // Stored public meets public and none requirements.
-    EXPECT_TRUE(vPublic->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
-    EXPECT_FALSE(vPublic->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
-    EXPECT_TRUE(vPublic->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
-    EXPECT_FALSE(vPublic->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+    EXPECT_TRUE(vPublic->permitsInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_FALSE(vPublic->permitsInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_TRUE(vPublic->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_FALSE(vPublic->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
 
     // Stored none meets none requirements.
-    EXPECT_TRUE(vNone->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
-    EXPECT_FALSE(vNone->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
-    EXPECT_FALSE(vNone->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
-    EXPECT_FALSE(vNone->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+    EXPECT_TRUE(vNone->permitsInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_FALSE(vNone->permitsInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_FALSE(vNone->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_FALSE(vNone->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
 
     // Stored empty meets none requirements.
-    EXPECT_TRUE(vEmpty->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::NONE));
-    EXPECT_FALSE(vEmpty->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
-    EXPECT_FALSE(vEmpty->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
-    EXPECT_FALSE(vEmpty->hasMinimumInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
+    EXPECT_TRUE(vEmpty->permitsInterfaceType(libcellml::Variable::InterfaceType::NONE));
+    EXPECT_FALSE(vEmpty->permitsInterfaceType(libcellml::Variable::InterfaceType::PRIVATE));
+    EXPECT_FALSE(vEmpty->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC));
+    EXPECT_FALSE(vEmpty->permitsInterfaceType(libcellml::Variable::InterfaceType::PUBLIC_AND_PRIVATE));
 }
 
 TEST(Variable, connectionsPersistAfterImporting)

--- a/tests/variable/variable.cpp
+++ b/tests/variable/variable.cpp
@@ -1745,14 +1745,6 @@ TEST(Variable, variableInterfaceDontDowngradeFromPublicAndPrivate)
 
 TEST(Variable, minimumInterfaceType)
 {
-    /*
-     *    argument : stored interface type = return value
-     *    (anything) : public_and_private = true
-     *    private : public = false
-     *    public : private = false
-     *    public, private, public_and_private : none = false
-     *    none : (anything) = true
-     */
     auto vPublic = libcellml::Variable::create("vPublic");
     vPublic->setInterfaceType("public");
 

--- a/tests/variable/variable.cpp
+++ b/tests/variable/variable.cpp
@@ -1700,6 +1700,49 @@ TEST(Variable, variableInterfaceDontDowngrade)
     EXPECT_EQ("public", v4->interfaceType());
 }
 
+TEST(Variable, variableInterfaceDontDowngradeFromPublicAndPrivate)
+{
+    libcellml::ModelPtr model = libcellml::Model::create();
+    libcellml::ComponentPtr c1 = libcellml::Component::create();
+    libcellml::ComponentPtr c2 = libcellml::Component::create();
+    libcellml::ComponentPtr c3 = libcellml::Component::create();
+
+    model->setName("model");
+    c1->setName("c1");
+    c2->setName("c2");
+    c3->setName("c3");
+
+    model->addComponent(c1);
+    c1->addComponent(c2);
+    c2->addComponent(c3);
+
+    libcellml::VariablePtr v1 = libcellml::Variable::create();
+    v1->setName("v1");
+    v1->setUnits("dimensionless");
+    v1->setInterfaceType("public_and_private");
+
+    libcellml::VariablePtr v2 = libcellml::Variable::create();
+    v2->setName("v2");
+    v2->setUnits("dimensionless");
+
+    libcellml::VariablePtr v3 = libcellml::Variable::create();
+    v3->setName("v3");
+    v3->setUnits("dimensionless");
+
+    c1->addVariable(v1);
+    c2->addVariable(v2);
+    c3->addVariable(v3);
+
+    libcellml::Variable::addEquivalence(v1, v2);
+    libcellml::Variable::addEquivalence(v2, v3);
+
+    EXPECT_FALSE(model->fixVariableInterfaces());
+
+    EXPECT_EQ("public_and_private", v1->interfaceType());
+    EXPECT_EQ("public_and_private", v2->interfaceType());
+    EXPECT_EQ("public", v3->interfaceType());
+}
+
 TEST(Variable, connectionsPersistAfterImporting)
 {
     auto model = libcellml::Model::create("model");


### PR DESCRIPTION
Addresses #717 

This introduces a minimum requirement when fixing the interface types.  The new `hasMinimumInterfaceType` will return:

     *    Parameter (right) /
     *   Stored value (below) | none | public | private | public_and_private  
     *   ---------------------+------+--------+---------+-------------------
     *                   none | T    | F      | F       | F
     *   ---------------------+------+--------+---------+-------------------
     *                 public | T    | T      | F       | F
     *   ---------------------+------+--------+---------+-------------------
     *                private | T    | F      | T       | F
     *   ---------------------+------+--------+---------+-------------------
     *     public_and_private | T    | T      | T       | T










