### PR TITLE
XmlDoc: compress the XHTML+MathML+SVG DTD only once

### DIFF
--- a/src/xmldoc.cpp
+++ b/src/xmldoc.cpp
@@ -112,7 +112,11 @@ void XmlDoc::parseMathML(const std::string &input)
     // Decompress the MathML DTD.
     int sizeMathmlDTDUncompressed = MATHML_DTD_LEN;
 
-    std::string mathMLDTD = decompressMathMLDTD();
+    static std::string mathMLDTD;
+
+    if (mathMLDTD.empty()) {
+        mathMLDTD = decompressMathMLDTD();
+    }
 
     xmlInitParser();
     xmlParserCtxtPtr context = xmlNewParserCtxt();


### PR DESCRIPTION
The `test` targets now runs ~33% faster (at least, on my MBP). Sweet. 🥳