### PR TITLE
Expose cellmlElementTypeAsString in the Python bindings.

### DIFF
--- a/src/bindings/interface/enums.i
+++ b/src/bindings/interface/enums.i
@@ -4,6 +4,9 @@
 
 %include <std_string.i>
 
+%feature("docstring") libcellml::cellmlElementTypeAsString
+"Convert a CellmlElementType enumeration value into its string form.";
+
 %{
 #include "libcellml/enums.h"
 %}

--- a/src/bindings/interface/enums.i
+++ b/src/bindings/interface/enums.i
@@ -2,11 +2,11 @@
 
 #define LIBCELLML_EXPORT
 
+%include <std_string.i>
+
 %{
 #include "libcellml/enums.h"
 %}
-
-%ignore libcellml::cellmlElementTypeAsString;
 
 %pythoncode %{
 # libCellML generated wrapper code starts here.

--- a/src/bindings/python/__init__.py
+++ b/src/bindings/python/__init__.py
@@ -17,7 +17,7 @@ from libcellml.analysermodel import AnalyserModel
 from libcellml.analyservariable import AnalyserVariable
 from libcellml.annotator import Annotator
 from libcellml.component import Component
-from libcellml.enums import CellmlElementType
+from libcellml.enums import CellmlElementType, cellmlElementTypeAsString
 from libcellml.generator import Generator
 from libcellml.generatorprofile import GeneratorProfile
 from libcellml.importer import Importer

--- a/tests/bindings/python/test_annotator.py
+++ b/tests/bindings/python/test_annotator.py
@@ -526,7 +526,7 @@ class AnnotatorTestCase(unittest.TestCase):
         self.assertEqual(non_unique_message, annotator.issue(0).description())
 
     def test_any_cellml_element(self):
-        from libcellml import Annotator, AnyCellmlElement, Parser
+        from libcellml import Annotator, AnyCellmlElement, Parser, cellmlElementTypeAsString
         from libcellml.enums import CellmlElementType
 
         self.assertRaises(AttributeError, AnyCellmlElement)
@@ -539,6 +539,7 @@ class AnnotatorTestCase(unittest.TestCase):
 
         item = annotator.item('component_1')
         self.assertEqual(CellmlElementType.COMPONENT, item.type())
+        self.assertEqual("component", cellmlElementTypeAsString(item.type()))
         self.assertEqual('component1', item.component().name())
 
         item = annotator.item('component_ref_1')


### PR DESCRIPTION
Addresses #984.