### PR TITLE
Adding support for Python 3.8 macOS wheels

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -290,6 +290,10 @@ jobs:
             os: ubuntu-20.04
           - name: 'macOS'
             os: macos-12
+        exclude:
+          - os: macos-12
+            py: '3.7'
+
     steps:
       - name: Check out libCellML
         uses: actions/checkout@v2
@@ -310,16 +314,16 @@ jobs:
           echo "Setting build as: BUILD=cp${v/./}-*"
           echo ::set-output name=BUILD::cp${v/./}-*
           if [[ "macOS" == "${{ matrix.name }}" ]]; then
-            if [[ "${{ matrix.py }}" == "3.9" || "${{ matrix.py }}" == "3.10" ]]; then
-              echo "Setting MACOS_ARCHS as: ARCHS='x86_64 arm64'"
-              echo ::set-output name=ARCHS::"x86_64 arm64"
+            if [[ "${{ matrix.py }}" == "3.8" ]]; then
+              echo "Setting MACOS_ARCHS as: MACOS_ARCHS='x86_64'"
+              echo ::set-output name=MACOS_ARCHS::x86_64
             else
-              echo "Setting MACOS_ARCHS as: ARCHS='x86_64'"
-              echo ::set-output name=ARCHS::x86_64
+              echo "Setting MACOS_ARCHS as: MACOS_ARCHS='x86_64 arm64'"
+              echo ::set-output name=MACOS_ARCHS::"x86_64 arm64"
             fi
           else
-            echo "Setting OTHER_ARCHS as: ARCHS='x86_64'"
-            echo ::set-output name=ARCHS::x86_64
+            echo "Setting MACOS_ARCHS as: MACOS_ARCHS='x86_64'"
+            echo ::set-output name=MACOS_ARCHS::x86_64
           fi
 
       - name: Configure MSVC
@@ -339,7 +343,7 @@ jobs:
         env:
           #CIBW_BUILD_VERBOSITY: 1
           CIBW_ARCHS: auto64
-          CIBW_ARCHS_MACOS: ${{ steps.setup.outputs.archs }}
+          CIBW_ARCHS_MACOS: ${{ steps.setup.outputs.macos_archs }}
           CIBW_BUILD: ${{ steps.setup.outputs.build }}
           CIBW_TEST_SKIP: "*_arm64"
           CIBW_BEFORE_ALL_LINUX: yum install -y libxml2-devel || (apk add libxml2-dev && rm /usr/lib/cmake/libxml2/libxml2-config.cmake)

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -290,11 +290,6 @@ jobs:
             os: ubuntu-20.04
           - name: 'macOS'
             os: macos-12
-        exclude:
-          - os: macos-12
-            py: '3.7'
-          - os: macos-12
-            py: '3.8'
     steps:
       - name: Check out libCellML
         uses: actions/checkout@v2
@@ -314,6 +309,18 @@ jobs:
           #echo ::set-output name=TAG::v0.2.0-dev.21
           echo "Setting build as: BUILD=cp${v/./}-*"
           echo ::set-output name=BUILD::cp${v/./}-*
+          if [[ "macOS" == "${{ matrix.name }}" ]]; then
+            if [[ "${{ matrix.py }}" == "3.9" || "${{ matrix.py }}" == "3.10" ]]; then
+              echo "Setting MACOS_ARCHS as: ARCHS='x86_64 arm64'"
+              echo ::set-output name=ARCHS::"x86_64 arm64"
+            else
+              echo "Setting MACOS_ARCHS as: ARCHS='x86_64'"
+              echo ::set-output name=ARCHS::x86_64
+            fi
+          else
+            echo "Setting OTHER_ARCHS as: ARCHS='x86_64'"
+            echo ::set-output name=ARCHS::x86_64
+          fi
 
       - name: Configure MSVC
         if: runner.os == 'Windows'
@@ -332,14 +339,14 @@ jobs:
         env:
           #CIBW_BUILD_VERBOSITY: 1
           CIBW_ARCHS: auto64
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: ${{ steps.setup.outputs.archs }}
           CIBW_BUILD: ${{ steps.setup.outputs.build }}
           CIBW_TEST_SKIP: "*_arm64"
           CIBW_BEFORE_ALL_LINUX: yum install -y libxml2-devel || (apk add libxml2-dev && rm /usr/lib/cmake/libxml2/libxml2-config.cmake)
           CIBW_BEFORE_ALL_WINDOWS: cd src/bindings/python && cmake -S wheel_dependencies -B build-wheel_dependencies -G Ninja && cd build-wheel_dependencies && ninja
           CIBW_ENVIRONMENT: LIBCELLML_VERSION_TAG=${{ steps.setup.outputs.tag }}
           CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET=11.0
+            MACOSX_DEPLOYMENT_TARGET=10.15
             LIBCELLML_VERSION_TAG=${{ steps.setup.outputs.tag }}
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
           CIBW_BEFORE_BUILD_LINUX: pip install renamewheel


### PR DESCRIPTION
To match other COMBINE standards we need to support Python 3.8 on macOS. These wheels will only have support for `x86_64` architecture.

Fixes #1033.