### PR TITLE
Use pip list instead of pip freeze to detect presence of Python package.

### DIFF
--- a/cmake/python_package_check.py
+++ b/cmake/python_package_check.py
@@ -1,13 +1,15 @@
 import subprocess
 import sys
 
-reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
-installed_packages = [r.decode().split('==')[0] for r in reqs.split()]
+reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'list'])
+
+output_lines = reqs.splitlines()
+# Remove two header lines from pip list output.
+output_lines = output_lines[2:]
+
+installed_packages = [r.decode().split()[0] for r in output_lines]
 
 check_package = sys.argv[1]
-if check_package in installed_packages:
-  result = 0
-else:
-  result = 1
+result = 0 if check_package in installed_packages else 1
 
 sys.exit(result)


### PR DESCRIPTION
Fixes #1051.