### PR TITLE
AnalyserVariable: hold onto the owning component reference.

### DIFF
--- a/src/analyser.cpp
+++ b/src/analyser.cpp
@@ -16,6 +16,9 @@ limitations under the License.
 
 #include "libcellml/analyser.h"
 
+#include <cmath>
+#include <iterator>
+
 #include "libcellml/analyserequation.h"
 #include "libcellml/analyserequationast.h"
 #include "libcellml/analyserexternalvariable.h"
@@ -28,9 +31,6 @@ limitations under the License.
 #include "libcellml/units.h"
 #include "libcellml/validator.h"
 #include "libcellml/variable.h"
-
-#include <cmath>
-#include <iterator>
 
 #include "analyserequation_p.h"
 #include "analyserequationast_p.h"

--- a/src/analyservariable.cpp
+++ b/src/analyservariable.cpp
@@ -16,9 +16,12 @@ limitations under the License.
 
 #include "libcellml/analyservariable.h"
 
+#include "libcellml/variable.h"
+
 #include <iterator>
 
 #include "analyservariable_p.h"
+#include "commonutils.h"
 
 namespace libcellml {
 
@@ -37,6 +40,7 @@ void AnalyserVariable::AnalyserVariableImpl::populate(AnalyserVariable::Type typ
     mIndex = index;
     mInitialisingVariable = initialisingVariable;
     mVariable = variable;
+    mComponent = owningComponent(mVariable);
 
     std::copy(equations.begin(), equations.end(), back_inserter(mEquations));
 }

--- a/src/analyservariable.cpp
+++ b/src/analyservariable.cpp
@@ -16,9 +16,9 @@ limitations under the License.
 
 #include "libcellml/analyservariable.h"
 
-#include "libcellml/variable.h"
-
 #include <iterator>
+
+#include "libcellml/variable.h"
 
 #include "analyservariable_p.h"
 #include "commonutils.h"

--- a/src/analyservariable_p.h
+++ b/src/analyservariable_p.h
@@ -33,6 +33,7 @@ struct AnalyserVariable::AnalyserVariableImpl
     size_t mIndex = 0;
     VariablePtr mInitialisingVariable;
     VariablePtr mVariable;
+    ComponentPtr mComponent;
     std::vector<AnalyserEquationWeakPtr> mEquations;
 
     static AnalyserVariablePtr create();

--- a/tests/generator/generator.cpp
+++ b/tests/generator/generator.cpp
@@ -1837,3 +1837,29 @@ TEST(Generator, variableInitialisedUsingAConstant)
 
     EXPECT_EQ(fileContents("generator/variable_initialised_using_a_constant/model.py"), generator->implementationCode());
 }
+
+TEST(Generator, modelOutOfScope)
+{
+    auto analyser = libcellml::Analyser::create();
+    {
+        auto parser = libcellml::Parser::create();
+        auto model = parser->parseModel(fileContents("generator/ode_multiple_dependent_odes/model.cellml"));
+
+        EXPECT_EQ(size_t(0), parser->issueCount());
+
+        analyser->analyseModel(model);
+    }
+
+    EXPECT_EQ(size_t(0), analyser->errorCount());
+
+    auto analyserModel = analyser->model();
+    auto generator = libcellml::Generator::create();
+
+    generator->setModel(analyserModel);
+
+    auto profile = libcellml::GeneratorProfile::create(libcellml::GeneratorProfile::Profile::PYTHON);
+
+    generator->setProfile(profile);
+
+    EXPECT_EQ(fileContents("generator/ode_multiple_dependent_odes/model.py"), generator->implementationCode());
+}


### PR DESCRIPTION
Fixes #1183.