### PR TITLE
Switch to using Here document

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -254,10 +254,8 @@ jobs:
         endif()
 
         file(GLOB _DIST_FILES ${ACTION_DIR}/build/dist/*)
-        # softprops action requires a list of newline separated files.
-        # The %0A will be converted by GitHub actions into '\n'.
-        string(REPLACE ";" "%0A" _DIST_FILES "${_DIST_FILES}")
-        file(APPEND $ENV{GITHUB_OUTPUT} "files=${_DIST_FILES}")
+        string(REPLACE ";" "\n" _DIST_FILES "${_DIST_FILES}")
+        file(APPEND $ENV{GITHUB_OUTPUT} "files<<EOF\n${_DIST_FILES}\nEOF")
 
     - name: Publish libraries
       if: needs.setup-jobs.outputs.binaries-destination == 'Publish'


### PR DESCRIPTION
Our old method of passing multi-line information through GITHUB_OUTPUT no longer works.  This change uses the currently documented method of using Here documents.

Fixes #1199.