### PR TITLE
Protect against empty classifiers in Python bindings.

### DIFF
--- a/src/bindings/python/cibuildwheel.setup.py
+++ b/src/bindings/python/cibuildwheel.setup.py
@@ -38,7 +38,7 @@ setup(
     url="https://libcellml.org",
     license="Apache 2.0",
     packages=["libcellml"],
-    classifiers=classifiers.split("\n"),
+    classifiers=[cl for cl in classifiers.split("\n") if cl],
     long_description=open('README.rst').read(),
     long_description_content_type='text/x-rst',
     include_package_data=True,

--- a/src/bindings/python/pre_gen.setup.in.py
+++ b/src/bindings/python/pre_gen.setup.in.py
@@ -50,7 +50,7 @@ setup(
     url='@PYPI_PACKAGE_URL@',
     license='Apache Software License',
     description=doclines[0],
-    classifiers=classifiers.split("\n"),
+    classifiers=[cl for cl in classifiers.split("\n") if cl],
     long_description=open('README.rst').read(),
     long_description_content_type='text/x-rst',
     distclass=BinaryDistribution,


### PR DESCRIPTION
Fixes #1214.