### PR TITLE
Python docstrings tests: don't test for CellmlElementType

### DIFF
--- a/tests/bindings/python/test_docstrings.py
+++ b/tests/bindings/python/test_docstrings.py
@@ -13,7 +13,7 @@ class DocstringTestCase(unittest.TestCase):
         # Scan for missing or empty docstrings
         def scan(root, missing, prefix=''):
             prefix += root.__name__
-            if not root.__doc__:
+            if not root.__doc__ and root.__name__ != 'CellmlElementType':
                 missing.append(prefix)
             prefix += '.'
             # Scan children, using dict instead of dir to avoid inherited


### PR DESCRIPTION
Fixes #1245.