### PR TITLE
Still require this undefine for older macOS.

### DIFF
--- a/src/analyserequationast.cpp
+++ b/src/analyserequationast.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 
 #include "analyserequationast_p.h"
 
+#include "libcellml/undefines.h"
+
 namespace libcellml {
 
 void AnalyserEquationAst::AnalyserEquationAstImpl::populate(AnalyserEquationAst::Type type,


### PR DESCRIPTION
Fixes #1298.