### PR TITLE
Update version to `0.7.0-rc.1`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum OS X deployment vers
 
 set(PROJECT_NAME libCellML)
 set(PROJECT_URL https://libcellml.org)
-set(_PROJECT_VERSION 0.6.3)
-set(PROJECT_DEVELOPER_VERSION)
+set(_PROJECT_VERSION 0.7.0)
+set(PROJECT_DEVELOPER_VERSION -rc.1)
 project(${PROJECT_NAME} VERSION ${_PROJECT_VERSION} LANGUAGES CXX)
 
 # Set policies that affect the build.


### PR DESCRIPTION
There still needs to be some process which updates the version identifier immediately after a release is made (see #1370).