### PR TITLE
Set identity of Git user to github actions bot for tagging release source

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Tag source of release
         run: |
           cd source-repo
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "source-v${{ inputs.version }}" -m "Source tag for release v${{ inputs.version }}"
           git push origin "source-v${{ inputs.version }}"
 


### PR DESCRIPTION
Part of #1380.